### PR TITLE
get component name from svelte:options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ npm install --save sveltedoc-parser
 | **ignoredVisibilities** | The list of ignored visibilities. | `['private', 'protected']` |
 | **includeSourceLocations** | Flag, which indicates that source locations should be provided for component symbols. | `false` |
 | **version** | Optional. Use `2` or `3` to specify which svelte syntax should be used. When that is not provided, parser try to detect version of the syntax. | `undefined` |
-| **defaultVersion** | Optional. Specify default version of svelte syntax, if auto-detector can't indetify correct version. | `undefined` |
+| **defaultVersion** | Optional. Specify default version of svelte syntax, if auto-detector can't identify correct version. | `undefined` |
 
 ### Supported feature names
 

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -698,6 +698,12 @@ class Parser extends EventEmitter {
                         this.emit('slot', slot);
                     }
                 } else {
+                    if (tagName === 'svelte:options' && attrs.tag) {
+                        if (this.features.includes('name')) {
+                            this.emit('name', attrs.tag);
+                        }
+                    }
+
                     if (this.features.includes('events')) {
                         // Expose events that propogated from child events
                         // Handle event syntax like ```<button on:click>Some link</button>```

--- a/test/svelte3/integration/basic/basic.name.wc.svelte
+++ b/test/svelte3/integration/basic/basic.name.wc.svelte
@@ -1,0 +1,1 @@
+<svelte:options tag="tag-name" />

--- a/test/svelte3/integration/basic/basic.spec.js
+++ b/test/svelte3/integration/basic/basic.spec.js
@@ -5,7 +5,7 @@ const expect = chai.expect;
 const parser = require('../../../../index');
 
 describe('SvelteDoc v3 - Basic', () => {
-    it('If name is not provided for component, name should be readed from file name', (done) => {
+    it('If name is not provided for component, name should be read from file name', (done) => {
         parser.parse({
             version: 3,
             filename: path.resolve(__dirname, 'basic.name.svelte'),
@@ -14,6 +14,22 @@ describe('SvelteDoc v3 - Basic', () => {
         }).then((doc) => {
             expect(doc, 'Document should be provided').to.exist;
             expect(doc.name, 'Document should have proper name').to.equal('basic.name');
+
+            done();
+        }).catch(e => {
+            done(e);
+        });
+    });
+
+    it('should read name from options-tag when compiling as a custom element', (done) => {
+        parser.parse({
+            version: 3,
+            filename: path.resolve(__dirname, 'basic.name.wc.svelte'),
+            features: ['name'],
+            ignoredVisibilities: []
+        }).then((doc) => {
+            expect(doc, 'Document should be provided').to.exist;
+            expect(doc.name, 'Document should have proper name').to.equal('tag-name');
 
             done();
         }).catch(e => {


### PR DESCRIPTION
When compiling to custom elements we could get the component name from the options tag `<svelte:options tag="tag-name" />`