### PR TITLE
Enable getting type from comment for 'ExportNamedDeclaration'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,7 @@ const getVisibility = (keywords, defaultVisibility) => {
     return defaultVisibility;
 };
 
-const parseComment = (text, defaultVisibility = DEFAULT_VISIBILITY, features = ['description', 'keywords']) => {
+const parseComment = (text, defaultVisibility = DEFAULT_VISIBILITY) => {
     const result = {
         keywords: [],
         visibility: defaultVisibility,
@@ -47,29 +47,19 @@ const parseComment = (text, defaultVisibility = DEFAULT_VISIBILITY, features = [
         index = matches.index;
 
         const name = matches[1];
-        const description = features.includes('description')
-            ? (matches[4] || '').trim()
-            : '';
+        const description = (matches[4] || '').trim();
 
         result.keywords.push({ name, description });
     }
 
-    if (features.includes('description')) {
-        result.description = parsedText.substring(0, indexDescription).trim();
-    }
-
+    result.description = parsedText.substring(0, indexDescription).trim();
     result.visibility = getVisibility(result.keywords, result.visibility);
-
-    if (!features.includes('keywords')) {
-        result.keywords = [];
-    }
 
     return result;
 };
 
 const getComment = (property, {
     defaultVisibility = DEFAULT_VISIBILITY,
-    features,
     useFirst = false,
     useLeading = true,
     useTrailing = true
@@ -91,7 +81,7 @@ const getComment = (property, {
     }
 
     if (lastComment) {
-        return parseComment(lastComment, defaultVisibility, features);
+        return parseComment(lastComment, defaultVisibility);
     }
 
     return {

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -333,7 +333,7 @@ class Parser extends EventEmitter {
                 const declaration = node.declaration;
 
                 if (declaration) {
-                    const exportNodeComment = utils.getComment(node, { defaultVisibility: 'public', features: this.features, useLeading: true, useTrailing: false });
+                    const exportNodeComment = utils.getComment(node, { defaultVisibility: 'public', useLeading: true, useTrailing: false });
 
                     if (declaration.type === 'VariableDeclaration') {
                         const variables = this.parseVariableDeclaration(declaration);

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -13,6 +13,7 @@ const DEFAULT_OPTIONS = {};
 
 const SUPPORTED_FEATURES = [
     'name',
+    'keywords',
     'data',
     'computed',
     'methods',

--- a/test/svelte3/integration/data/data.public.svelte
+++ b/test/svelte3/integration/data/data.public.svelte
@@ -1,8 +1,9 @@
 <script>
-    export let variable = 'hello';
+  export let variable = "hello";
 
-    /**
-     * The property comment.
-     */
-    export let propertyWithComment;
+  /**
+   * The property comment.
+   * @type {string}
+   */
+  export let propertyWithComment;
 </script>

--- a/test/svelte3/integration/data/data.spec.js
+++ b/test/svelte3/integration/data/data.spec.js
@@ -43,7 +43,7 @@ describe('SvelteDoc v3 - Props', () => {
         parser.parse({
             version: 3,
             filename: path.resolve(__dirname, 'data.public.svelte'),
-            features: ['data', 'description', 'keywords'],
+            features: ['data'],
             ignoredVisibilities: []
         }).then((doc) => {
             expect(doc, 'Document should be provided').to.exist;

--- a/test/svelte3/integration/data/data.spec.js
+++ b/test/svelte3/integration/data/data.spec.js
@@ -43,11 +43,11 @@ describe('SvelteDoc v3 - Props', () => {
         parser.parse({
             version: 3,
             filename: path.resolve(__dirname, 'data.public.svelte'),
-            features: ['data', 'description'],
+            features: ['data', 'description', 'keywords'],
             ignoredVisibilities: []
         }).then((doc) => {
             expect(doc, 'Document should be provided').to.exist;
-            expect(doc.data, 'Document events should be parsed').to.exist;
+            expect(doc.data, 'Document data should be parsed').to.exist;
 
             expect(doc.data.length).to.equal(2);
             const variableItem = doc.data.find(item => item.name === 'variable');
@@ -63,7 +63,7 @@ describe('SvelteDoc v3 - Props', () => {
             expect(variableWithCommentItem.visibility).to.equal('public');
             expect(variableWithCommentItem.static).to.be.false;
             expect(variableWithCommentItem.description).to.be.equal('The property comment.');
-            expect(variableWithCommentItem.type).to.eql({ kind: 'type', type: 'any', text: 'any' });
+            expect(variableWithCommentItem.type).to.eql({ kind: 'type', type: 'string', text: 'string' });
             expect(variableWithCommentItem.defaultValue).to.equal(undefined);
 
             done();


### PR DESCRIPTION
added 'keywords' to SUPPORTED_FEATURES in `v3/parser.js`.
added test case for getting type from comment.

Another way to solve this is by not passing this.features to `utils.getComment` when `node.type === 'ExportNamedDeclaration'` (v3/parser.js:336) - I'm not sure why there is a special handling for this case. Maybe it is better if parseComment always extracts keywords? Any reason not to?