### PR TITLE
fix(v3-parser): Export metadata for method.param items (#39)

### DIFF
--- a/examples/Button.json
+++ b/examples/Button.json
@@ -132,7 +132,7 @@
             "keywords": [
                 {
                     "name": "param",
-                    "description": "{string} question a question about life, the universe, everything"
+                    "description": "{string} [question=Why?] a question about life, the universe, everything"
                 },
                 {
                     "name": "returns",
@@ -142,9 +142,17 @@
             "visibility": "public",
             "description": "Computes the answer to your question.",
             "name": "computeAnswer",
-            "args": [
+            "params": [
                 {
-                    "name": "question"
+                    "type": {
+                        "kind": "type",
+                        "text": "string",
+                        "type": "string"
+                    },
+                    "name": "question",
+                    "optional": true,
+                    "default": "Why?",
+                    "description": "a question about life, the universe, everything"
                 }
             ],
             "return": {

--- a/examples/Button.json
+++ b/examples/Button.json
@@ -184,7 +184,6 @@
             "parent": "button",
             "modificators": [],
             "locations": null,
-            "loc": null,
             "visibility": "public",
             "description": "",
             "keywords": []

--- a/examples/Button.svelte
+++ b/examples/Button.svelte
@@ -33,11 +33,11 @@
 
     /**
      * Computes the answer to your question.
-     * @param {string} question a question about life, the universe, everything
+     * @param {string} [question=Why?] a question about life, the universe, everything
      * @returns {number} the answer to all your questions
      */
     export function computeAnswer(question) {
-       return question.indexOf("?") >= 0 ? 42 : 23;
+       return question.indexOf('?') >= 0 ? 42 : 23;
     };
 </script>
 

--- a/lib/jsdoc.js
+++ b/lib/jsdoc.js
@@ -11,6 +11,14 @@ const RETURN_RE = new RegExp(`^\\s*(${TYPE})?(\\s*${TYPE_DESC})?`, 'i');
 
 const DEFAULT_TYPE = 'any';
 
+function getDefaultJSDocType() {
+    return {
+        kind: 'type',
+        text: '*',
+        type: DEFAULT_TYPE
+    };
+}
+
 function parseType(type, param) {
     if (type.indexOf('|') > -1) {
         param.type = type.split('|');
@@ -111,15 +119,10 @@ function parseTypeKeyword(text) {
 
 function parseParamKeyword(text) {
     const param = {
-        type: {
-            kind: 'type',
-            text: '*',
-            type: DEFAULT_TYPE
-        },
+        type: getDefaultJSDocType(),
         name: null,
         optional: false,
-        default: null,
-        description: null
+        default: null
     };
 
     const match = PARAM_RE.exec(text);
@@ -169,11 +172,7 @@ function parseParamKeyword(text) {
 
 function parseReturnKeyword(text) {
     const output = {
-        type: {
-            kind: 'type',
-            text: '*',
-            type: DEFAULT_TYPE
-        },
+        type: getDefaultJSDocType(),
         description: null
     };
     const matches = RETURN_RE.exec(text);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -169,7 +169,6 @@ class Parser extends EventEmitter {
                         start: p.key.start + this.scriptOffset,
                         end: p.key.end + this.scriptOffset
                     }];
-                    entry.loc = entry.locations[0];
                 }
             }
 
@@ -223,13 +222,13 @@ class Parser extends EventEmitter {
             } else if (property.key.name === 'components') {
                 if (p.value && p.value.type === 'Identifier') {
                     if (hasOwnProperty(this.imports, p.value.name)) {
-                        // TODO: 3.*, Backward compatibility: Remove this property
                         entry.importPath = this.imports[p.value.name].sourceFilename;
-                        entry.value = entry.importPath;
                     }
                 }
             } else if (entry.value instanceof utils.NodeFunction) {
-                entry.args = entry.value.params.map((param) => param.name);
+                entry.params = entry.value.params.map(
+                    (param) => ({ name: param.name })
+                );
             } else if (property.key.name === 'data') {
                 const typeKeyword = entry.keywords.find(kw => kw.name === 'type');
 
@@ -524,8 +523,6 @@ class Parser extends EventEmitter {
                                     start: next.start + this.scriptOffset,
                                     end: next.end + this.scriptOffset
                                 }];
-                                // TODO: Deprication - Remove this property with V3.*
-                                event.loc = event.locations[0];
                             }
                         }
 
@@ -612,8 +609,6 @@ class Parser extends EventEmitter {
                                 start: parser.startIndex,
                                 end: parser.endIndex
                             }];
-                            // TODO: Deprication - Remove this property with V3.*
-                            slot.loc = slot.locations[0];
                         }
 
                         this.emit('slot', slot);
@@ -627,10 +622,6 @@ class Parser extends EventEmitter {
                                 parent: tagName,
                                 locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
                                     ? [lastAttributeLocations[name]]
-                                    : null,
-                                // TODO: Deprication - Remove this property with V3.*
-                                loc: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
-                                    ? lastAttributeLocations[name]
                                     : null
                             }));
 
@@ -669,10 +660,6 @@ class Parser extends EventEmitter {
                                     modificators: nameWithModificators.slice(1),
                                     locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
                                         ? [lastAttributeLocations[name]]
-                                        : null,
-                                    // TODO: Deprication - Remove this property with V3.*
-                                    loc: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
-                                        ? lastAttributeLocations[name]
                                         : null
                                 };
                             });
@@ -693,10 +680,6 @@ class Parser extends EventEmitter {
                                     parent: null,
                                     locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
                                         ? [lastAttributeLocations[name]]
-                                        : null,
-                                    // TODO: Deprication - Remove this property with V3.*
-                                    loc: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
-                                        ? lastAttributeLocations[name]
                                         : null
                                 };
                             })

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -29,6 +29,16 @@ const SCOPE_DEFAULT = 'default';
 const SCOPE_STATIC = 'static';
 const SCOPE_MARKUP = 'markup';
 
+const PARAM_ALIASES = {
+    arg: true,
+    argument: true,
+    param: true
+};
+const RETURN_ALIASES = {
+    return: true,
+    returns: true,
+};
+
 class Parser extends EventEmitter {
     constructor(structure, options) {
         super();
@@ -133,9 +143,6 @@ class Parser extends EventEmitter {
                 start: variable.location.start + parseContext.offset,
                 end: variable.location.end + parseContext.offset,
             }];
-
-            // TODO: Deprication - remove after 3.*
-            item.loc = item.locations[0];
         }
 
         this.updateType(item);
@@ -160,9 +167,6 @@ class Parser extends EventEmitter {
                 start: method.location.start + parseContext.offset,
                 end: method.location.end + parseContext.offset
             }];
-
-            // TODO: Deprication - remove after 3.*
-            item.loc = item.locations[0];
         }
 
         this.emit('method', item);
@@ -180,9 +184,6 @@ class Parser extends EventEmitter {
                 start: computed.location.start + parseContext.offset,
                 end: computed.location.end + parseContext.offset
             }];
-
-            // TODO: Deprication - remove after 3.*
-            item.loc = item.locations[0];
         }
 
         this.updateType(item);
@@ -200,9 +201,6 @@ class Parser extends EventEmitter {
                 start: event.location.start + parseContext.offset,
                 end: event.location.end + parseContext.offset
             }];
-
-            // TODO: Deprication - remove after 3.*
-            item.loc = item.locations[0];
         }
 
         this.emit('event', item);
@@ -220,8 +218,6 @@ class Parser extends EventEmitter {
         const item = Object.assign({}, utils.getCommentFromSourceCode(component.node, parseContext.sourceCode, { defaultVisibility: 'private' }), {
             name: component.name,
             importPath: component.path,
-            // TODO: 3.*, Backward compatibility: Remove this property
-            value: component.path
         });
 
         if (this.includeSourceLocations && component.location) {
@@ -229,8 +225,6 @@ class Parser extends EventEmitter {
                 start: component.location.start + parseContext.offset,
                 end: component.location.end + parseContext.offset
             }];
-            // TODO: 3.*, Backward compatibility: Remove this property
-            item.loc = item.locations[0];
         }
 
         this.emit('component', item);
@@ -389,6 +383,7 @@ class Parser extends EventEmitter {
 
                     if (declaration.type === 'FunctionDeclaration') {
                         const func = this.parseFunctionDeclaration(declaration);
+
                         this.emitMethodItem(func, parseContext, 'public', exportNodeComment);
 
                         if (declaration.body) {
@@ -755,10 +750,6 @@ class Parser extends EventEmitter {
                                 modificators: nameWithModificators.slice(1),
                                 locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
                                     ? [lastAttributeLocations[name]]
-                                    : null,
-                                // TODO: Deprication, remove this property with 3.*
-                                loc: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
-                                    ? lastAttributeLocations[name]
                                     : null
                             };
 
@@ -859,10 +850,6 @@ class Parser extends EventEmitter {
                                     parent: tagName,
                                     locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
                                         ? [lastAttributeLocations[name]]
-                                        : null,
-                                    // TODO: Reprication, remove this property with 3.*
-                                    loc: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
-                                        ? lastAttributeLocations[name]
                                         : null
                                 };
                             });
@@ -876,8 +863,6 @@ class Parser extends EventEmitter {
                                     property: bindProperty.sourcePropertyName
                                 }],
                                 locations: bindProperty.locations,
-                                // TODO: Reprication, remove this property with 3.*
-                                loc: bindProperty.loc,
                                 visibility: 'private',
                                 static: false,
                                 readonly: false
@@ -896,10 +881,6 @@ class Parser extends EventEmitter {
                                 parent: tagName,
                                 locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, 'bind:this')
                                     ? [lastAttributeLocations['bind:this']]
-                                    : null,
-                                // TODO: Reprication, remove this property with 3.*
-                                loc: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, 'bind:this')
-                                    ? lastAttributeLocations['bind:this']
                                     : null
                             });
                         }
@@ -918,44 +899,39 @@ class Parser extends EventEmitter {
 
     /**
      * Mutates event.
-     * @param {any[]} keywords 
-     * @param {{ params?: any[] }} event 
+     * @param {any[]} keywords
+     * @param {{ params?: any[] }} event
      */
     parseKeywords(keywords = [], event) {
-        if (!event.params) event.params = [];
+        if (!event.params) {
+            event.params = [];
+        }
 
         keywords.forEach(({ name, description }) => {
-            switch (name) {
-                case 'arg':
-                case 'param':
-                case 'argument':
-                    const parsedParam = jsdoc.parseParamKeyword(description);
-                    const pIndex = event.params.findIndex(
-                        p => p.name === parsedParam.name
-                    );
+            if (name in PARAM_ALIASES) {
+                const parsedParam = jsdoc.parseParamKeyword(description);
+                const pIndex = event.params.findIndex(
+                    p => p.name === parsedParam.name
+                );
 
+                /*
+                 * Replace the param if there is already one present with
+                 * the same name. This will happen with parsed
+                 * FunctionDeclaration because params will already be
+                 * present from parsing the AST node.
+                 */
+                if (pIndex >= 0) {
+                    event.params[pIndex] = parsedParam;
+                } else {
                     /*
-                     * Replace the param if there is already one present with
-                     * the same name. This will happen with parsed
-                     * FunctionDeclaration because params will already be
-                     * present from parsing the AST node.
+                     * This means @param does not match an actual param
+                     * in the FunctionDeclaration.
+                     * TODO: Implement option to choose behaviour (keep, ignore, warn, throw)
                      */
-                    if (0 <= pIndex) {
-                        event.params[pIndex] = parsedParam;
-                    } else {
-                        /*
-                         * This means @param does not match an actual param
-                         * in the FunctionDeclaration.
-                         * Should we ignore it or warn about it?
-                         */
-                        event.params.push(parsedParam);
-                    }
-                    break;
-
-                case 'return':
-                case 'returns':
-                    event.return = jsdoc.parseReturnKeyword(description);
-                    break;
+                    event.params.push(parsedParam);
+                }
+            } else if (name in RETURN_ALIASES) {
+                event.return = jsdoc.parseReturnKeyword(description);
             }
         });
 

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -150,7 +150,7 @@ class Parser extends EventEmitter {
 
         const item = Object.assign({}, comment, {
             name: method.name,
-            args: method.args,
+            params: method.params,
             return: method.return,
             static: parseContext.scopeType === SCOPE_STATIC
         });
@@ -679,11 +679,11 @@ class Parser extends EventEmitter {
             throw new Error('Node should have a FunctionDeclarationType, but is ' + node.type);
         }
 
-        const args = [];
+        const params = [];
 
-        node.params.forEach(param => {
+        node.params.forEach((param) => {
             if (param.type === 'Identifier') {
-                args.push({
+                params.push({
                     name: param.name,
                 });
             }
@@ -696,7 +696,7 @@ class Parser extends EventEmitter {
                 start: node.id.start,
                 end: node.id.end
             },
-            args: args,
+            params: params,
         };
 
         return output;
@@ -916,15 +916,40 @@ class Parser extends EventEmitter {
         parser.end();
     }
 
+    /**
+     * Mutates event.
+     * @param {any[]} keywords 
+     * @param {{ params?: any[] }} event 
+     */
     parseKeywords(keywords = [], event) {
-        event.params = [];
+        if (!event.params) event.params = [];
 
         keywords.forEach(({ name, description }) => {
             switch (name) {
                 case 'arg':
                 case 'param':
                 case 'argument':
-                    event.params.push(jsdoc.parseParamKeyword(description));
+                    const parsedParam = jsdoc.parseParamKeyword(description);
+                    const pIndex = event.params.findIndex(
+                        p => p.name === parsedParam.name
+                    );
+
+                    /*
+                     * Replace the param if there is already one present with
+                     * the same name. This will happen with parsed
+                     * FunctionDeclaration because params will already be
+                     * present from parsing the AST node.
+                     */
+                    if (0 <= pIndex) {
+                        event.params[pIndex] = parsedParam;
+                    } else {
+                        /*
+                         * This means @param does not match an actual param
+                         * in the FunctionDeclaration.
+                         * Should we ignore it or warn about it?
+                         */
+                        event.params.push(parsedParam);
+                    }
                     break;
 
                 case 'return':

--- a/test/svelte2/integration/locations/locations.spec.js
+++ b/test/svelte2/integration/locations/locations.spec.js
@@ -16,10 +16,10 @@ describe('SvelteDoc - Source locations', () => {
             expect(doc.data.length).is.equals(1);
             const property = doc.data[0];
 
-            expect(property.loc).is.deep.equals({
+            expect(property.locations).to.deep.equal([{
                 start: 166,
                 end: 176
-            });
+            }]);
 
             done();
         }).catch(e => {
@@ -38,10 +38,10 @@ describe('SvelteDoc - Source locations', () => {
             expect(doc.methods.length).is.equals(1);
             const method = doc.methods[0];
 
-            expect(method.loc).is.deep.equals({
+            expect(method.locations).to.deep.equal([{
                 start: 221,
                 end: 226
-            });
+            }]);
 
             done();
         }).catch(e => {
@@ -60,10 +60,10 @@ describe('SvelteDoc - Source locations', () => {
             expect(doc.refs.length).is.equals(1);
             const ref = doc.refs[0];
 
-            expect(ref.loc).is.deep.equals({
+            expect(ref.locations).to.deep.equal([{
                 start: 4,
                 end: 15
-            });
+            }]);
 
             done();
         }).catch(e => {
@@ -82,10 +82,10 @@ describe('SvelteDoc - Source locations', () => {
             expect(doc.slots.length).is.equals(1);
             const slot = doc.slots[0];
 
-            expect(slot.loc).is.deep.equals({
+            expect(slot.locations).to.deep.equal([{
                 start: 64,
                 end: 81
-            });
+            }]);
 
             done();
         }).catch(e => {
@@ -105,26 +105,26 @@ describe('SvelteDoc - Source locations', () => {
             const markupPropogatedEvent = doc.events.find(e => e.name === 'mousemove');
 
             expect(markupPropogatedEvent).is.not.empty;
-            expect(markupPropogatedEvent.loc).is.deep.equals({
+            expect(markupPropogatedEvent.locations).to.deep.equal([{
                 start: 44,
                 end: 58
-            });
+            }]);
 
             const codeEvent = doc.events.find(e => e.name === 'codeEvent');
 
             expect(codeEvent).is.not.empty;
-            expect(codeEvent.loc).is.deep.equals({
+            expect(codeEvent.locations).to.deep.equal([{
                 start: 287,
                 end: 298
-            });
+            }]);
 
             const markupEvent = doc.events.find(e => e.name === 'markupEvent');
 
             expect(markupEvent).is.not.empty;
-            expect(markupEvent.loc).is.deep.equals({
+            expect(markupEvent.locations).to.deep.equal([{
                 start: 15,
                 end: 44
-            });
+            }]);
 
             done();
         }).catch(e => {
@@ -144,15 +144,15 @@ describe('SvelteDoc - Source locations', () => {
             const firstHelper = doc.helpers.find(h => h.name === 'window');
             const secondHelper = doc.helpers.find(h => h.name === 'helperFunc');
 
-            expect(firstHelper.loc).is.deep.equals({
+            expect(firstHelper.locations).to.deep.equal([{
                 start: 341,
                 end: 347
-            });
+            }]);
 
-            expect(secondHelper.loc).is.deep.equals({
+            expect(secondHelper.locations).to.deep.equal([{
                 start: 357,
                 end: 367
-            });
+            }]);
 
             done();
         }).catch(e => {

--- a/test/svelte2/integration/overall/overall.main.doc.json
+++ b/test/svelte2/integration/overall/overall.main.doc.json
@@ -19,10 +19,6 @@
                     "end": 1084
                 }
             ],
-            "loc": {
-                "start": 1080,
-                "end": 1084
-            },
             "type": {
                 "kind": "union",
                 "text": "'default'|'night'",
@@ -58,10 +54,6 @@
                     "end": 1212
                 }
             ],
-            "loc": {
-                "start": 1203,
-                "end": 1212
-            },
             "type": {
                 "kind": "type",
                 "text": "Array<any>",
@@ -89,10 +81,6 @@
                     "end": 1357
                 }
             ],
-            "loc": {
-                "start": 1347,
-                "end": 1357
-            },
             "type": {
                 "kind": "type",
                 "text": "string",
@@ -120,10 +108,6 @@
                     "end": 1504
                 }
             ],
-            "loc": {
-                "start": 1493,
-                "end": 1504
-            },
             "type": {
                 "kind": "type",
                 "text": "string",
@@ -142,10 +126,6 @@
                     "end": 1538
                 }
             ],
-            "loc": {
-                "start": 1522,
-                "end": 1538
-            },
             "type": {
                 "kind": "type",
                 "text": "boolean",
@@ -164,10 +144,6 @@
                     "end": 1570
                 }
             ],
-            "loc": {
-                "start": 1559,
-                "end": 1570
-            },
             "type": {
                 "kind": "type",
                 "text": "any",
@@ -186,10 +162,6 @@
                     "end": 1609
                 }
             ],
-            "loc": {
-                "start": 1588,
-                "end": 1609
-            },
             "type": {
                 "kind": "type",
                 "text": "number",
@@ -208,10 +180,6 @@
                     "end": 1636
                 }
             ],
-            "loc": {
-                "start": 1627,
-                "end": 1636
-            },
             "type": {
                 "kind": "type",
                 "text": "string",
@@ -231,10 +199,6 @@
                     "end": 1766
                 }
             ],
-            "loc": {
-                "start": 1758,
-                "end": 1766
-            },
             "dependencies": [
                 "_"
             ]
@@ -250,10 +214,6 @@
                     "end": 1820
                 }
             ],
-            "loc": {
-                "start": 1813,
-                "end": 1820
-            },
             "dependencies": [
                 "menuItems"
             ]
@@ -275,13 +235,6 @@
                     "start": 2104,
                     "end": 2112
                 }
-            ],
-            "loc": {
-                "start": 2104,
-                "end": 2112
-            },
-            "args": [
-                "actionName"
             ],
             "params": [
                 {
@@ -312,13 +265,6 @@
                     "start": 2171,
                     "end": 2188
                 }
-            ],
-            "loc": {
-                "start": 2171,
-                "end": 2188
-            },
-            "args": [
-                "event"
             ]
         }
     ],
@@ -333,13 +279,6 @@
                     "start": 2357,
                     "end": 2364
                 }
-            ],
-            "loc": {
-                "start": 2357,
-                "end": 2364
-            },
-            "args": [
-                "node"
             ]
         }
     ],
@@ -355,11 +294,7 @@
                     "start": 1905,
                     "end": 1911
                 }
-            ],
-            "loc": {
-                "start": 1905,
-                "end": 1911
-            }
+            ]
         }
     ],
     "components": [
@@ -374,11 +309,7 @@
                     "start": 768,
                     "end": 774
                 }
-            ],
-            "loc": {
-                "start": 768,
-                "end": 774
-            }
+            ]
         },
         {
             "visibility": "public",
@@ -391,11 +322,7 @@
                     "start": 803,
                     "end": 807
                 }
-            ],
-            "loc": {
-                "start": 803,
-                "end": 807
-            }
+            ]
         },
         {
             "visibility": "public",
@@ -408,11 +335,7 @@
                     "start": 834,
                     "end": 842
                 }
-            ],
-            "loc": {
-                "start": 834,
-                "end": 842
-            }
+            ]
         },
         {
             "visibility": "public",
@@ -425,11 +348,7 @@
                     "start": 873,
                     "end": 888
                 }
-            ],
-            "loc": {
-                "start": 873,
-                "end": 888
-            }
+            ]
         }
     ],
     "description": "The entry-point component for 'Overall' page of Web-Application.",
@@ -451,11 +370,7 @@
                     "start": 2294,
                     "end": 2307
                 }
-            ],
-            "loc": {
-                "start": 2294,
-                "end": 2307
-            }
+            ]
         }
     ],
     "slots": [
@@ -468,11 +383,7 @@
                     "start": 370,
                     "end": 375
                 }
-            ],
-            "loc": {
-                "start": 370,
-                "end": 375
-            }
+            ]
         },
         {
             "name": "footer",
@@ -483,11 +394,7 @@
                     "start": 548,
                     "end": 567
                 }
-            ],
-            "loc": {
-                "start": 548,
-                "end": 567
-            }
+            ]
         }
     ],
     "transitions": [
@@ -501,13 +408,6 @@
                     "start": 2571,
                     "end": 2576
                 }
-            ],
-            "loc": {
-                "start": 2571,
-                "end": 2576
-            },
-            "args": [
-                "node"
             ]
         }
     ],
@@ -521,10 +421,6 @@
                     "end": 55
                 }
             ],
-            "loc": {
-                "start": 44,
-                "end": 55
-            },
             "visibility": "public",
             "description": "",
             "keywords": []
@@ -538,10 +434,6 @@
                     "end": 187
                 }
             ],
-            "loc": {
-                "start": 178,
-                "end": 187
-            },
             "visibility": "public",
             "description": "",
             "keywords": []
@@ -555,10 +447,6 @@
                     "end": 220
                 }
             ],
-            "loc": {
-                "start": 202,
-                "end": 220
-            },
             "visibility": "public",
             "description": "",
             "keywords": []
@@ -572,10 +460,6 @@
                     "end": 360
                 }
             ],
-            "loc": {
-                "start": 351,
-                "end": 360
-            },
             "visibility": "public",
             "description": "",
             "keywords": []
@@ -589,10 +473,6 @@
                     "end": 538
                 }
             ],
-            "loc": {
-                "start": 527,
-                "end": 538
-            },
             "visibility": "public",
             "description": "",
             "keywords": []

--- a/test/svelte3/integration/components/components.spec.js
+++ b/test/svelte3/integration/components/components.spec.js
@@ -13,25 +13,25 @@ describe('SvelteDoc v3 - Components', () => {
             includeSourceLocations: true,
             ignoredVisibilities: []
         }).then((doc) => {
+            // Document
             expect(doc, 'Document should be provided').to.exist;
             expect(doc.components, 'Document components should be parsed').to.exist;
-
             expect(doc.components.length).to.equal(1);
+
+            // Component
             const component = doc.components[0];
 
             expect(component.name).to.equal('Nested');
-            expect(component.value).to.equal('./components.nested.svelte');
             expect(component.importPath).to.equal('./components.nested.svelte');
             expect(component.visibility).to.equal('private');
-
             expect(component.description).to.equal('The nested component.');
-
             expect(component.locations, 'Code location should be included').to.be.exist;
-            expect(component.locations.length).to.be.equal(1);
+            expect(component.locations.length).to.equal(1);
 
+            // Location
             const location = component.locations[0];
 
-            expect(location, 'Location should be correct identified').is.deep.equals({ start: 53, end: 59 });
+            expect(location, 'Location should be correctly identified').is.deep.equal({ start: 53, end: 59 });
 
             done();
         }).catch(e => {

--- a/test/svelte3/integration/methods/method.public.svelte
+++ b/test/svelte3/integration/methods/method.public.svelte
@@ -1,6 +1,8 @@
 <script>
     /**
      * The method comment.
+     * @param {string} param1 - the first parameter
+     * @param {boolean} [param2=false] - the second parameter
      * @returns {number} - return value description
      */
     export function publicMethod(param1, param2) {

--- a/test/svelte3/integration/methods/methods.spec.js
+++ b/test/svelte3/integration/methods/methods.spec.js
@@ -23,10 +23,10 @@ describe('SvelteDoc v3 - Methods', () => {
             expect(method.visibility).to.equal('private');
             expect(method.static).to.be.false;
 
-            expect(method.args, 'Method arguments should be parsed').to.exist;
-            expect(method.args.length).to.equal(2);
-            expect(method.args[0].name).to.equal('param1');
-            expect(method.args[1].name).to.equal('param2');
+            expect(method.params, 'Method arguments should be parsed').to.exist;
+            expect(method.params.length).to.equal(2);
+            expect(method.params[0].name).to.equal('param1');
+            expect(method.params[1].name).to.equal('param2');
 
             expect(method.description).to.equal('The method comment.');
 
@@ -56,21 +56,31 @@ describe('SvelteDoc v3 - Methods', () => {
             ignoredVisibilities: []
         }).then((doc) => {
             expect(doc, 'Document should be provided').to.exist;
+
             expect(doc.methods, 'Document methods should be parsed').to.exist;
-
             expect(doc.methods.length).to.equal(1);
-            const method = doc.methods[0];
 
+            const method = doc.methods[0];
             expect(method.name).to.equal('publicMethod');
             expect(method.visibility).to.equal('public');
             expect(method.static).to.be.false;
             expect(method.description).to.equal('The method comment.');
 
-            expect(method.args, 'Method arguments should be parsed').to.exist;
-            expect(method.args.length).to.equal(2);
-            expect(method.args[0].name).to.equal('param1');
-            expect(method.args[1].name).to.equal('param2');
+            // @param keywords
+            expect(method.params, 'Method arguments should be parsed').to.exist;
+            expect(method.params.length).to.equal(2);
 
+            const param0 = method.params[0];
+            expect(param0.name).to.equal('param1');
+            expect(param0.description).to.equal('the first parameter');
+            expect(param0.optional).to.be.false;
+
+            const param1 = method.params[1];
+            expect(param1.name).to.equal('param2');
+            expect(param1.description).to.equal('the second parameter');
+            expect(param1.optional).to.be.true;
+
+            // @returns keyword
             expect(method.return, 'Method return keyword should be parsed').to.exist;
             expect(method.return.type).to.exist;
             expect(method.return.type.type).to.equal('number');

--- a/test/svelte3/integration/methods/methods.spec.js
+++ b/test/svelte3/integration/methods/methods.spec.js
@@ -61,6 +61,7 @@ describe('SvelteDoc v3 - Methods', () => {
             expect(doc.methods.length).to.equal(1);
 
             const method = doc.methods[0];
+
             expect(method.name).to.equal('publicMethod');
             expect(method.visibility).to.equal('public');
             expect(method.static).to.be.false;
@@ -71,11 +72,13 @@ describe('SvelteDoc v3 - Methods', () => {
             expect(method.params.length).to.equal(2);
 
             const param0 = method.params[0];
+
             expect(param0.name).to.equal('param1');
             expect(param0.description).to.equal('the first parameter');
             expect(param0.optional).to.be.false;
 
             const param1 = method.params[1];
+
             expect(param1.name).to.equal('param2');
             expect(param1.description).to.equal('the second parameter');
             expect(param1.optional).to.be.true;

--- a/test/unit/jsdoc/jsdoc.spec.js
+++ b/test/unit/jsdoc/jsdoc.spec.js
@@ -367,7 +367,7 @@ describe('JSDoc parser module tests', () => {
 
             expect(returns).to.exist;
             expect(returns.description).to.equal('return description');
-            
+
             expect(returns.type).to.exist;
             expect(returns.type.kind).to.equal('type');
             expect(returns.type.type).to.equal('any');
@@ -378,7 +378,7 @@ describe('JSDoc parser module tests', () => {
 
             expect(returns).to.exist;
             expect(returns.description).to.equal('return description');
-            
+
             expect(returns.type).to.exist;
             expect(returns.type.kind).to.equal('type');
             expect(returns.type.type).to.equal('any');
@@ -411,7 +411,7 @@ describe('JSDoc parser module tests', () => {
 
             expect(returns).to.exist;
             expect(returns.description).to.equal('return description');
-            
+
             expect(returns.type).to.exist;
             expect(returns.type.kind).to.equal('type');
             expect(returns.type.type).to.equal('any');

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -189,7 +189,7 @@ export interface SvelteComputedItem extends ISvelteItem {
     dependencies: string[]    
 }
 
-export interface SvelteMethodArgumentItem {
+export interface SvelteMethodParamItem {
     /**
      * The name of method parameter.
      */
@@ -223,6 +223,9 @@ export interface SvelteMethodArgumentItem {
     static?: boolean;
 }
 
+export type SvelteArgItem = SvelteMethodParamItem;
+export type SvelteArgumentItem = SvelteMethodParamItem;
+
 export interface SvelteMethodReturnItem {
     /**
      * The JSDocType of the return value.
@@ -238,7 +241,7 @@ export interface SvelteMethodItem extends ISvelteItem {
     /**
      * The list of parameter items of the method.
      */
-    args?: SvelteMethodArgumentItem[];
+    params?: SvelteMethodParamItem[];
     /**
      * The return item of the method. This exists if an item with 'name' equal
      * to 'returns' or 'return' exists in 'keywords'.

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -79,13 +79,6 @@ export interface ISvelteItem {
     name: string;
 
     /**
-     * The source code location of this item.
-     * Provided only if requested by specific option parameter.
-     * @deprecated This field marked as depricated, please use `locations` instead of this.
-     */
-    loc?: SourceLocation;
-
-    /**
      * The list of source code locations for this item.
      * Provided only if requested by specific option parameter.
      */
@@ -250,12 +243,6 @@ export interface SvelteMethodItem extends ISvelteItem {
 }
 
 export interface SvelteComponentItem extends ISvelteItem {
-    /**
-     * The relative path to improted component.
-     * @deprecated Use `importPath` instead of this property.
-     */
-    value: string;
-
     /**
      * The relative path of importing of this object.
      * When not defined, so variable is not provided.


### PR DESCRIPTION
- Parse `@param` from JSDoc
- Add function getDefaultJSDocType
- Update tests for svelte3/integration/methods
- Fix typings for SvelteMethodItem
- Add example usage