### PR TITLE
feat(options): Improve validation for parsers internal options (#29)

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -2,6 +2,7 @@ const { isString, printArray, isVisibilitySupported, VISIBILITIES } = require('.
 
 /**
  * @typedef {import("../typings").SvelteParserOptions} SvelteParserOptions
+ * @typedef {import("../typings").JSVisibilityScope} JSVisibilityScope
  */
 
 /** @type {BufferEncoding[]} */
@@ -43,12 +44,14 @@ const OptionsError = Object.freeze({
     IgnoredVisibilitiesMissing: 'Internal Error: options.ignoredVisibilities is not set.',
     IgnoredVisibilitiesFormat: ERROR_VISIBILITIES_FORMAT + INFO_VISIBILITIES_SUPPORTED,
     IgnoredVisibilitiesNotSupported: (arr) => getUnsupportedVisibilitiesString(arr),
+    IncludeSourceLocationsMissing: 'Internal Error: options.includeSourceLocationsMissing is not set.',
+    IncludeSourceLocationsFormat: 'Expected options.includeSourceLocations to be a boolean.',
 });
 
 /** @type {BufferEncoding} */
 const DEFAULT_ENCODING = 'utf8';
 
-/** @type {SymbolVisibility[]} */
+/** @type {JSVisibilityScope[]} */
 const DEFAULT_IGNORED_VISIBILITIES = ['protected', 'private'];
 
 /** @returns {SvelteParserOptions} */
@@ -56,6 +59,7 @@ function getDefaultOptions() {
     return {
         encoding: DEFAULT_ENCODING,
         ignoredVisibilities: [...DEFAULT_IGNORED_VISIBILITIES],
+        includeSourceLocations: false,
     };
 }
 
@@ -70,11 +74,10 @@ function retrieveFileOptions(options) {
 
 /**
  * Applies default values to options.
- * @param {SvelteParserOptions} options
+ * @param {SvelteParserOptions} options object to normalize (mutated)
+ * @param {SvelteParserOptions} defaults default values to normalize 'options'
  */
-function normalize(options) {
-    const defaults = getDefaultOptions();
-
+function normalize(options, defaults) {
     Object.keys(defaults).forEach((optionKey) => {
         /**
          * If the key was not set by the user, apply default value.
@@ -97,7 +100,7 @@ function validate(options) {
         throw new Error(OptionsError.OptionsRequired);
     }
 
-    normalize(options);
+    normalize(options, getDefaultOptions());
 
     const hasFilename =
         ('filename' in options) &&
@@ -122,7 +125,7 @@ function validate(options) {
             throw new Error(OptionsError.EncodingNotSupported(options.encoding));
         }
     } else {
-        // Sanity check. At this point, 'encoding' should be set.
+        // Sanity check. At this point, 'encoding' must be set.
         throw new Error(OptionsError.EncodingMissing);
     }
 
@@ -139,8 +142,17 @@ function validate(options) {
             throw new Error(OptionsError.IgnoredVisibilitiesNotSupported(notSupported));
         }
     } else {
-        // Sanity check. At this point, 'ignoredVisibilities' should be set.
+        // Sanity check. At this point, 'ignoredVisibilities' must be set.
         throw new Error(OptionsError.IgnoredVisibilitiesMissing);
+    }
+
+    if ('includeSourceLocations' in options) {
+        if (typeof options.includeSourceLocations !== 'boolean') {
+            throw new TypeError(OptionsError.IncludeSourceLocationsFormat);
+        }
+    } else {
+        // Sanity check. At this point, 'includeSourceLocations' must be set.
+        throw new Error(OptionsError.IncludeSourceLocationsMissing);
     }
 }
 
@@ -170,7 +182,7 @@ const ParserError = {
 
 /**
  *
- * @param {*} options
+ * @param {SvelteParserOptions} options
  * @param {string[]} supported
  * @throws if any validation fails for options.features
  */
@@ -232,6 +244,7 @@ function getAstDefaultOptions() {
 module.exports = {
     OptionsError,
     ParserError,
+    normalize,
     validate,
     validateFeatures,
     retrieveFileOptions,

--- a/lib/options.js
+++ b/lib/options.js
@@ -34,7 +34,7 @@ function getUnsupportedVisibilitiesString(arr) {
         INFO_VISIBILITIES_SUPPORTED;
 }
 
-const ErrorMessage = Object.freeze({
+const OptionsError = Object.freeze({
     OptionsRequired: 'An options object is required.',
     InputRequired: 'One of options.filename or options.fileContent is required.',
     EncodingMissing: 'Internal Error: options.encoding is not set.',
@@ -94,7 +94,7 @@ function normalize(options) {
  */
 function validate(options) {
     if (!options) {
-        throw new Error(ErrorMessage.OptionsRequired);
+        throw new Error(OptionsError.OptionsRequired);
     }
 
     normalize(options);
@@ -110,25 +110,25 @@ function validate(options) {
         isString(options.fileContent);
 
     if (!hasFilename && !hasFileContent) {
-        throw new Error(ErrorMessage.InputRequired);
+        throw new Error(OptionsError.InputRequired);
     }
 
     if ('encoding' in options) {
         if (!isString(options.encoding)) {
-            throw new Error(ErrorMessage.EncodingFormat);
+            throw new Error(OptionsError.EncodingFormat);
         }
 
         if (!ENCODINGS.includes(options.encoding)) {
-            throw new Error(ErrorMessage.EncodingNotSupported(options.encoding));
+            throw new Error(OptionsError.EncodingNotSupported(options.encoding));
         }
     } else {
         // Sanity check. At this point, 'encoding' should be set.
-        throw new Error(ErrorMessage.EncodingMissing);
+        throw new Error(OptionsError.EncodingMissing);
     }
 
     if ('ignoredVisibilities' in options) {
         if (!Array.isArray(options.ignoredVisibilities)) {
-            throw new Error(ErrorMessage.IgnoredVisibilitiesFormat);
+            throw new Error(OptionsError.IgnoredVisibilitiesFormat);
         }
 
         if (!options.ignoredVisibilities.every(isVisibilitySupported)) {
@@ -136,16 +136,104 @@ function validate(options) {
                 (iv) => !isVisibilitySupported(iv)
             );
 
-            throw new Error(ErrorMessage.IgnoredVisibilitiesNotSupported(notSupported));
+            throw new Error(OptionsError.IgnoredVisibilitiesNotSupported(notSupported));
         }
     } else {
         // Sanity check. At this point, 'ignoredVisibilities' should be set.
-        throw new Error(ErrorMessage.IgnoredVisibilitiesMissing);
+        throw new Error(OptionsError.IgnoredVisibilitiesMissing);
     }
 }
 
+const getSupportedFeaturesString = (supported) => `Supported features: ${printArray(supported)}`;
+
+const getFeaturesEmptyString = (supported) => {
+    return 'options.features must contain at least one feature. ' +
+        getSupportedFeaturesString(supported);
+};
+
+/**
+ * @param {string[]} notSupported
+ * @param {string[]} supported
+ */
+const getFeaturesNotSupportedString = (notSupported, supported) => {
+    return `Features [${printArray(notSupported)}] in ` +
+        'options.features are not supported by this Parser. ' +
+        getSupportedFeaturesString(supported);
+};
+
+const ParserError = {
+    FeaturesMissing: 'Internal Error: options.features is not set.',
+    FeaturesFormat: 'options.features must be an array',
+    FeaturesEmpty: getFeaturesEmptyString,
+    FeaturesNotSupported: getFeaturesNotSupportedString,
+};
+
+/**
+ *
+ * @param {*} options
+ * @param {string[]} supported
+ * @throws if any validation fails for options.features
+ */
+function validateFeatures(options, supported) {
+    if ('features' in options) {
+        if (!Array.isArray(options.features)) {
+            throw new TypeError(ParserError.FeaturesFormat);
+        }
+
+        if (options.features.length === 0) {
+            throw new Error(ParserError.FeaturesEmpty(supported));
+        }
+
+        const notSupported = options.features.filter((iv) => !supported.includes(iv));
+
+        if (notSupported.length > 0) {
+            throw new Error(ParserError.FeaturesNotSupported(notSupported, supported));
+        }
+    } else {
+        throw new Error(ParserError.FeaturesMissing);
+    }
+}
+
+/**
+ * @link https://github.com/eslint/espree#options
+ */
+function getAstDefaultOptions() {
+    return {
+        /** attach range information to each node */
+        range: true,
+
+        /** attach line/column location information to each node */
+        loc: true,
+
+        /** create a top-level comments array containing all comments */
+        comment: true,
+
+        /** create a top-level tokens array containing all tokens */
+        tokens: true,
+
+        /**
+         * Set to 3, 5 (default), 6, 7, 8, 9, 10, 11, or 12 to specify
+         * the version of ECMAScript syntax you want to use.
+         *
+         * You can also set to 2015 (same as 6), 2016 (same as 7),
+         * 2017 (same as 8), 2018 (same as 9), 2019 (same as 10),
+         * 2020 (same as 11), or 2021 (same as 12) to use the year-based naming.
+         */
+        ecmaVersion: 9,
+
+        /** specify which type of script you're parsing ("script" or "module") */
+        sourceType: 'module',
+
+        /** specify additional language features */
+        ecmaFeatures: {}
+    };
+}
+
 module.exports = {
-    ErrorMessage: ErrorMessage,
-    validate: validate,
-    retrieveFileOptions: retrieveFileOptions,
+    OptionsError,
+    ParserError,
+    validate,
+    validateFeatures,
+    retrieveFileOptions,
+    getAstDefaultOptions,
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -8,27 +8,40 @@ const jsdoc = require('./jsdoc');
 
 const hasOwnProperty = utils.hasOwnProperty;
 
-const DEFAULT_OPTIONS = {
-    /**
-     * Flag, indicating that source locations should be extracted from source.
-     */
-    includeSourceLocations: false,
-    range: false,
-    // comment: true,
-    attachComment: true,
+/**
+ * @link https://github.com/eslint/espree#options
+ */
+function getAstDefaultOptions() {
+    return {
+        /** attach range information to each node */
+        range: true,
 
-    // create a top-level tokens array containing all tokens
-    tokens: true,
+        /** attach line/column location information to each node */
+        loc: true,
 
-    // The version of ECMAScript syntax to use
-    ecmaVersion: 9,
+        /** create a top-level comments array containing all comments */
+        comment: true,
 
-    // Type of script to parse
-    sourceType: 'module',
+        /** create a top-level tokens array containing all tokens */
+        tokens: true,
 
-    ecmaFeatures: {
-    }
-};
+        /**
+         * Set to 3, 5 (default), 6, 7, 8, 9, 10, 11, or 12 to specify
+         * the version of ECMAScript syntax you want to use.
+         *
+         * You can also set to 2015 (same as 6), 2016 (same as 7),
+         * 2017 (same as 8), 2018 (same as 9), 2019 (same as 10),
+         * 2020 (same as 11), or 2021 (same as 12) to use the year-based naming.
+         */
+        ecmaVersion: 9,
+
+        /** specify which type of script you're parsing ("script" or "module") */
+        sourceType: 'module',
+
+        /** specify additional language features */
+        ecmaFeatures: {}
+    };
+}
 
 const SUPPORTED_FEATURES = [
     'name',
@@ -46,25 +59,32 @@ const SUPPORTED_FEATURES = [
     'refs',
     'store'
 ];
+const isFeatureSupported = (v) => SUPPORTED_FEATURES.includes(v);
+
+const INFO_FEATURES_SUPPORTED = `Supported features: ${JSON.stringify(SUPPORTED_FEATURES)}`;
+
+function getUnsupporteFeaturesString(arr) {
+    return `Features [${utils.printArray(arr)}] in ` +
+        'options.features are not supported by the SvelteV2 Parser. ' +
+        INFO_FEATURES_SUPPORTED;
+}
 
 const EVENT_EMIT_RE = /\bfire\s*\(\s*((?:'[^']*')|(?:"[^"]*")|(?:`[^`]*`))/;
 
 class Parser extends EventEmitter {
     constructor(options) {
-        options = Object.assign({}, DEFAULT_OPTIONS, options);
+        super();
 
         Parser.validateOptions(options);
 
-        super();
-
         this.source = options.source;
-        this.features = options.features || SUPPORTED_FEATURES;
+        this.features = options.features;
 
         if (hasOwnProperty(options.source, 'script') && options.source.script) {
             this.scriptOffset = options.source.scriptOffset || 0;
 
             try {
-                this.ast = espree.parse(options.source.script, options);
+                this.ast = espree.parse(options.source.script, options.ast);
 
                 this.sourceCode = new eslint.SourceCode({
                     text: options.source.script,
@@ -73,11 +93,14 @@ class Parser extends EventEmitter {
             } catch (e) {
                 const script = utils.escapeImportKeyword(options.source.script);
 
-                this.ast = espree.parse(script, Object.assign({}, options, {
+                const newAstOptions = {
+                    ...options.ast,
                     loc: true,
                     range: true,
                     comment: true
-                }));
+                };
+
+                this.ast = espree.parse(script, newAstOptions);
 
                 this.sourceCode = new eslint.SourceCode({
                     text: script,
@@ -91,31 +114,86 @@ class Parser extends EventEmitter {
         }
 
         this.includeSourceLocations = options.includeSourceLocations;
-        this.componentName = null;
+        this.componentName = options.componentName;
         this.template = options.source.template;
         this.filename = options.filename;
-        this.eventsEmmited = {};
+        this.eventsEmmited = options.eventsEmmited;
         this.defaultMethodVisibility = options.defaultMethodVisibility;
         this.defaultActionVisibility = options.defaultActionVisibility;
-        this.identifiers = {};
-        this.imports = {};
+        this.identifiers = options.identifiers;
+        this.imports = options.imports;
+    }
+
+    static getDefaultOptions() {
+        return {
+            includeSourceLocations: true,
+            defaultMethodVisibility: utils.DEFAULT_VISIBILITY,
+            defaultActionVisibility: utils.DEFAULT_VISIBILITY,
+            features: [...SUPPORTED_FEATURES],
+            componentName: null,
+            eventsEmmited: {},
+            identifiers: {},
+            imports: {},
+            ast: getAstDefaultOptions(),
+        };
+    }
+
+    static normalizeOptions(options) {
+        const defaults = Parser.getDefaultOptions();
+
+        Object.keys(defaults).forEach((optionKey) => {
+            // If the key was not set by the user, apply default value.
+            if (!(optionKey in options)) {
+                options[optionKey] = defaults[optionKey];
+            }
+        });
     }
 
     static validateOptions(options) {
-        if (!options.source) {
-            throw new Error('options.source is required');
+        Parser.normalizeOptions(options);
+
+        // Check the presence and basic format of multiple options
+        for (const key of ['eventsEmmited', 'identifiers', 'imports']) {
+            const hasKey = (key in options);
+
+            if (!hasKey) {
+                throw new Error(`options.${key} is required`);
+            }
+
+            const hasCorrectType = typeof options[key] === 'object';
+
+            if (!hasCorrectType) {
+                throw new TypeError(`options.${key} must be of type 'object'`);
+            }
         }
 
-        if (options.features) {
+        if ('source' in options) {
+            ['script', 'scriptOffset'].forEach(key => {
+                if (!(key in options.source)) {
+                    throw new TypeError('options.source must have keys \'script\' and \'scriptOffset\'');
+                }
+            });
+        }
+
+        if ('features' in options) {
             if (!Array.isArray(options.features)) {
                 throw new TypeError('options.features must be an array');
             }
 
-            options.features.forEach((feature) => {
-                if (!SUPPORTED_FEATURES.includes(feature)) {
-                    throw new Error(`Unknow '${feature}' feature. Supported features: ` + JSON.stringify(SUPPORTED_FEATURES));
-                }
-            });
+            if (options.features.length === 0) {
+                throw new Error(
+                    'options.features must contain at least one feature. ' +
+                    INFO_FEATURES_SUPPORTED
+                );
+            }
+
+            if (!options.features.every(isFeatureSupported)) {
+                const notSupported = options.features.filter(
+                    (iv) => !isFeatureSupported(iv)
+                );
+
+                throw new Error(getUnsupporteFeaturesString(notSupported));
+            }
         }
     }
 
@@ -379,19 +457,15 @@ class Parser extends EventEmitter {
     }
 
     internalWalk() {
-        if (this.features.length === 0) {
-            return this.emit('end');
-        }
-
         if (this.template) {
             this.parseTemplate();
         }
 
-        if (this.ast === null) {
-            if (this.features.includes('name')) {
-                this.parseComponentName();
-            }
+        if (this.features.includes('name')) {
+            this.parseComponentName();
+        }
 
+        if (this.ast === null) {
             return this.emit('end');
         }
 
@@ -449,10 +523,6 @@ class Parser extends EventEmitter {
                 }
             } else if (body.expression !== null && body.expression.right && body.expression.right.properties) {
                 body.expression.right.properties.forEach((property) => this.extractProperties(property));
-            }
-
-            if (this.features.includes('name')) {
-                this.parseComponentName();
             }
         });
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -5,43 +5,9 @@ const HtmlParser = require('htmlparser2-svelte').Parser;
 const path = require('path');
 const utils = require('./utils');
 const jsdoc = require('./jsdoc');
+const { validateFeatures, getAstDefaultOptions } = require('./options');
 
 const hasOwnProperty = utils.hasOwnProperty;
-
-/**
- * @link https://github.com/eslint/espree#options
- */
-function getAstDefaultOptions() {
-    return {
-        /** attach range information to each node */
-        range: true,
-
-        /** attach line/column location information to each node */
-        loc: true,
-
-        /** create a top-level comments array containing all comments */
-        comment: true,
-
-        /** create a top-level tokens array containing all tokens */
-        tokens: true,
-
-        /**
-         * Set to 3, 5 (default), 6, 7, 8, 9, 10, 11, or 12 to specify
-         * the version of ECMAScript syntax you want to use.
-         *
-         * You can also set to 2015 (same as 6), 2016 (same as 7),
-         * 2017 (same as 8), 2018 (same as 9), 2019 (same as 10),
-         * 2020 (same as 11), or 2021 (same as 12) to use the year-based naming.
-         */
-        ecmaVersion: 9,
-
-        /** specify which type of script you're parsing ("script" or "module") */
-        sourceType: 'module',
-
-        /** specify additional language features */
-        ecmaFeatures: {}
-    };
-}
 
 const SUPPORTED_FEATURES = [
     'name',
@@ -59,15 +25,6 @@ const SUPPORTED_FEATURES = [
     'refs',
     'store'
 ];
-const isFeatureSupported = (v) => SUPPORTED_FEATURES.includes(v);
-
-const INFO_FEATURES_SUPPORTED = `Supported features: ${JSON.stringify(SUPPORTED_FEATURES)}`;
-
-function getUnsupporteFeaturesString(arr) {
-    return `Features [${utils.printArray(arr)}] in ` +
-        'options.features are not supported by the SvelteV2 Parser. ' +
-        INFO_FEATURES_SUPPORTED;
-}
 
 const EVENT_EMIT_RE = /\bfire\s*\(\s*((?:'[^']*')|(?:"[^"]*")|(?:`[^`]*`))/;
 
@@ -117,7 +74,7 @@ class Parser extends EventEmitter {
         this.componentName = options.componentName;
         this.template = options.source.template;
         this.filename = options.filename;
-        this.eventsEmmited = options.eventsEmmited;
+        this.eventsEmitted = options.eventsEmitted;
         this.defaultMethodVisibility = options.defaultMethodVisibility;
         this.defaultActionVisibility = options.defaultActionVisibility;
         this.identifiers = options.identifiers;
@@ -131,7 +88,7 @@ class Parser extends EventEmitter {
             defaultActionVisibility: utils.DEFAULT_VISIBILITY,
             features: [...SUPPORTED_FEATURES],
             componentName: null,
-            eventsEmmited: {},
+            eventsEmitted: {},
             identifiers: {},
             imports: {},
             ast: getAstDefaultOptions(),
@@ -153,7 +110,7 @@ class Parser extends EventEmitter {
         Parser.normalizeOptions(options);
 
         // Check the presence and basic format of multiple options
-        for (const key of ['eventsEmmited', 'identifiers', 'imports']) {
+        for (const key of ['eventsEmitted', 'identifiers', 'imports']) {
             const hasKey = (key in options);
 
             if (!hasKey) {
@@ -175,26 +132,7 @@ class Parser extends EventEmitter {
             });
         }
 
-        if ('features' in options) {
-            if (!Array.isArray(options.features)) {
-                throw new TypeError('options.features must be an array');
-            }
-
-            if (options.features.length === 0) {
-                throw new Error(
-                    'options.features must contain at least one feature. ' +
-                    INFO_FEATURES_SUPPORTED
-                );
-            }
-
-            if (!options.features.every(isFeatureSupported)) {
-                const notSupported = options.features.filter(
-                    (iv) => !isFeatureSupported(iv)
-                );
-
-                throw new Error(getUnsupporteFeaturesString(notSupported));
-            }
-        }
+        validateFeatures(options, SUPPORTED_FEATURES);
     }
 
     static getEventName(feature) {
@@ -276,13 +214,13 @@ class Parser extends EventEmitter {
                     keywords: entry.keywords
                 };
 
-                if (hasOwnProperty(this.eventsEmmited, event.name)) {
-                    const emitedEvent = this.eventsEmmited[event.name];
+                if (hasOwnProperty(this.eventsEmitted, event.name)) {
+                    const emitedEvent = this.eventsEmitted[event.name];
 
                     if (emitedEvent.parent) {
                         event.visibility = 'public';
 
-                        this.eventsEmmited[event.name] = event;
+                        this.eventsEmitted[event.name] = event;
 
                         this.parseKeywords(entry.keywords, event);
                         this.emit('event', event);
@@ -290,7 +228,7 @@ class Parser extends EventEmitter {
                         // This event already defined
                     }
                 } else {
-                    this.eventsEmmited[event.name] = event;
+                    this.eventsEmitted[event.name] = event;
 
                     this.parseKeywords(entry.keywords, event);
                     this.emit('event', event);
@@ -617,15 +555,15 @@ class Parser extends EventEmitter {
                     if (!event.name) {
                         event.name = '****unhandled-event-name****';
                     } else {
-                        if (hasOwnProperty(this.eventsEmmited, event.name)) {
-                            const emitedEvent = this.eventsEmmited[event.name];
+                        if (hasOwnProperty(this.eventsEmitted, event.name)) {
+                            const emitedEvent = this.eventsEmitted[event.name];
 
                             if (emitedEvent.visibility === 'public') {
                                 continue;
                             }
                         }
 
-                        this.eventsEmmited[event.name] = event;
+                        this.eventsEmitted[event.name] = event;
                     }
 
                     this.parseKeywords(event.keywords, event);
@@ -769,8 +707,8 @@ class Parser extends EventEmitter {
                             event.description = comment.description || '';
                             event.keywords = comment.keywords;
 
-                            if (!hasOwnProperty(this.eventsEmmited, event.name)) {
-                                this.eventsEmmited[event.name] = event;
+                            if (!hasOwnProperty(this.eventsEmitted, event.name)) {
+                                this.eventsEmitted[event.name] = event;
 
                                 this.parseKeywords(comment.keywords, event);
                                 this.emit('event', event);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -5,7 +5,11 @@ const HtmlParser = require('htmlparser2-svelte').Parser;
 const path = require('path');
 const utils = require('./utils');
 const jsdoc = require('./jsdoc');
-const { validateFeatures, getAstDefaultOptions } = require('./options');
+const {
+    normalize: normalizeOptions,
+    validateFeatures,
+    getAstDefaultOptions
+} = require('./options');
 
 const hasOwnProperty = utils.hasOwnProperty;
 
@@ -28,101 +32,83 @@ const SUPPORTED_FEATURES = [
 
 const EVENT_EMIT_RE = /\bfire\s*\(\s*((?:'[^']*')|(?:"[^"]*")|(?:`[^`]*`))/;
 
+function generateSourceCode(options) {
+    const generated = {
+        ast: null,
+        sourceCode: null,
+        scriptOffset: 0,
+    };
+
+    if (!(hasOwnProperty(options.source, 'script') && options.source.script)) {
+        return generated;
+    }
+
+    try {
+        generated.ast = espree.parse(
+            options.source.script,
+            getAstDefaultOptions()
+        );
+
+        generated.sourceCode = new eslint.SourceCode({
+            text: options.source.script,
+            ast: generated.ast
+        });
+    } catch (e) {
+        const script = utils.escapeImportKeyword(options.source.script);
+
+        generated.ast = espree.parse(script, getAstDefaultOptions());
+
+        generated.sourceCode = new eslint.SourceCode({
+            text: script,
+            ast: generated.ast
+        });
+    }
+
+    generated.scriptOffset = options.source.scriptOffset || 0;
+
+    return generated;
+}
+
 class Parser extends EventEmitter {
     constructor(options) {
         super();
 
         Parser.validateOptions(options);
 
-        this.source = options.source;
-        this.features = options.features;
-
-        if (hasOwnProperty(options.source, 'script') && options.source.script) {
-            this.scriptOffset = options.source.scriptOffset || 0;
-
-            try {
-                this.ast = espree.parse(options.source.script, options.ast);
-
-                this.sourceCode = new eslint.SourceCode({
-                    text: options.source.script,
-                    ast: this.ast
-                });
-            } catch (e) {
-                const script = utils.escapeImportKeyword(options.source.script);
-
-                const newAstOptions = {
-                    ...options.ast,
-                    loc: true,
-                    range: true,
-                    comment: true
-                };
-
-                this.ast = espree.parse(script, newAstOptions);
-
-                this.sourceCode = new eslint.SourceCode({
-                    text: script,
-                    ast: this.ast
-                });
-            }
-        } else {
-            this.scriptOffset = 0;
-            this.ast = null;
-            this.sourceCode = null;
-        }
-
-        this.includeSourceLocations = options.includeSourceLocations;
-        this.componentName = options.componentName;
-        this.template = options.source.template;
+        // External options
         this.filename = options.filename;
-        this.eventsEmitted = options.eventsEmitted;
-        this.defaultMethodVisibility = options.defaultMethodVisibility;
-        this.defaultActionVisibility = options.defaultActionVisibility;
-        this.identifiers = options.identifiers;
-        this.imports = options.imports;
+        this.source = options.source;
+        this.template = options.source.template;
+        this.features = options.features;
+        this.includeSourceLocations = options.includeSourceLocations;
+
+        // Internal Properties
+        this.defaultMethodVisibility = utils.DEFAULT_VISIBILITY;
+        this.defaultActionVisibility = utils.DEFAULT_VISIBILITY;
+        this.componentName = null;
+        this.eventsEmitted = {};
+        this.identifiers = {};
+        this.imports = {};
+
+        // Generated Espree AST
+        const { ast, sourceCode, scriptOffset } = generateSourceCode(options);
+
+        this.ast = ast;
+        this.sourceCode = sourceCode;
+        this.scriptOffset = scriptOffset;
     }
 
     static getDefaultOptions() {
         return {
             includeSourceLocations: true,
-            defaultMethodVisibility: utils.DEFAULT_VISIBILITY,
-            defaultActionVisibility: utils.DEFAULT_VISIBILITY,
-            features: [...SUPPORTED_FEATURES],
-            componentName: null,
-            eventsEmitted: {},
-            identifiers: {},
-            imports: {},
-            ast: getAstDefaultOptions(),
+            features: [...SUPPORTED_FEATURES]
         };
     }
 
-    static normalizeOptions(options) {
-        const defaults = Parser.getDefaultOptions();
-
-        Object.keys(defaults).forEach((optionKey) => {
-            // If the key was not set by the user, apply default value.
-            if (!(optionKey in options)) {
-                options[optionKey] = defaults[optionKey];
-            }
-        });
-    }
-
     static validateOptions(options) {
-        Parser.normalizeOptions(options);
+        normalizeOptions(options, Parser.getDefaultOptions());
 
-        // Check the presence and basic format of multiple options
-        for (const key of ['eventsEmitted', 'identifiers', 'imports']) {
-            const hasKey = (key in options);
-
-            if (!hasKey) {
-                throw new Error(`options.${key} is required`);
-            }
-
-            const hasCorrectType = typeof options[key] === 'object';
-
-            if (!hasCorrectType) {
-                throw new TypeError(`options.${key} must be of type 'object'`);
-            }
-        }
+        validateFeatures(options, SUPPORTED_FEATURES);
 
         if ('source' in options) {
             ['script', 'scriptOffset'].forEach(key => {
@@ -131,8 +117,6 @@ class Parser extends EventEmitter {
                 }
             });
         }
-
-        validateFeatures(options, SUPPORTED_FEATURES);
     }
 
     static getEventName(feature) {

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -7,10 +7,9 @@ const HtmlParser = require('htmlparser2-svelte').Parser;
 
 const utils = require('./../utils');
 const jsdoc = require('./../jsdoc');
+const { validateFeatures, getAstDefaultOptions } = require('../options');
 
-const hasOwnProperty = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
-
-const DEFAULT_OPTIONS = {};
+const hasOwnProperty = utils.hasOwnProperty;
 
 const SUPPORTED_FEATURES = [
     'name',
@@ -24,7 +23,6 @@ const SUPPORTED_FEATURES = [
     'slots',
     'refs'
 ];
-
 const SCOPE_DEFAULT = 'default';
 const SCOPE_STATIC = 'static';
 const SCOPE_MARKUP = 'markup';
@@ -43,21 +41,21 @@ class Parser extends EventEmitter {
     constructor(options) {
         super();
 
-        this._options = Object.assign({}, DEFAULT_OPTIONS, options);
+        Parser.validateOptions(options);
 
         this.structure = options.structure;
-        this.features = options.features || SUPPORTED_FEATURES;
+        this.features = options.features;
         this.includeSourceLocations = options.includeSourceLocations;
-        this.componentName = null;
+        this.componentName = options.componentName;
         this.filename = options.filename;
-        this.eventsEmitted = {};
+        this.eventsEmitted = options.eventsEmitted;
         this.defaultMethodVisibility = options.defaultMethodVisibility;
         this.defaultActionVisibility = options.defaultActionVisibility;
-        this.identifiers = {};
-        this.imports = {};
+        this.identifiers = options.identifiers;
+        this.imports = options.imports;
 
-        this.dispatcherConstructorNames = [];
-        this.dispatcherNames = [];
+        this.dispatcherConstructorNames = options.dispatcherConstructorNames;
+        this.dispatcherNames = options.dispatcherNames;
     }
 
     walk() {
@@ -88,6 +86,53 @@ class Parser extends EventEmitter {
         }
 
         this.emit('end');
+    }
+
+    static getDefaultOptions() {
+        return {
+            includeSourceLocations: true,
+            defaultMethodVisibility: utils.DEFAULT_VISIBILITY,
+            defaultActionVisibility: utils.DEFAULT_VISIBILITY,
+            features: [...SUPPORTED_FEATURES],
+            componentName: null,
+            eventsEmitted: {},
+            identifiers: {},
+            imports: {},
+            dispatcherConstructorNames: [],
+            dispatcherNames: [],
+        };
+    }
+
+    static normalizeOptions(options) {
+        const defaults = Parser.getDefaultOptions();
+
+        Object.keys(defaults).forEach((optionKey) => {
+            // If the key was not set by the user, apply default value.
+            if (!(optionKey in options)) {
+                options[optionKey] = defaults[optionKey];
+            }
+        });
+    }
+
+    static validateOptions(options) {
+        Parser.normalizeOptions(options);
+
+        // Check the presence and basic format of multiple options
+        for (const key of ['eventsEmitted', 'identifiers', 'imports']) {
+            const hasKey = (key in options);
+
+            if (!hasKey) {
+                throw new Error(`options.${key} is required`);
+            }
+
+            const hasCorrectType = typeof options[key] === 'object';
+
+            if (!hasCorrectType) {
+                throw new TypeError(`options.${key} must be of type 'object'`);
+            }
+        }
+
+        validateFeatures(options, SUPPORTED_FEATURES);
     }
 
     static getEventName(feature) {
@@ -531,23 +576,10 @@ class Parser extends EventEmitter {
         });
     }
 
-    getAstParsingOptions() {
-        return {
-            tokens: true,
-            loc: true,
-            range: true,
-            ecmaVersion: 9,
-            sourceType: 'module',
-            comment: true,
-            ecmaFeatures: {
-            }
-        };
-    }
-
     parseScriptBlock(scriptBlock) {
         const ast = espree.parse(
             scriptBlock.content,
-            this.getAstParsingOptions()
+            getAstDefaultOptions()
         );
 
         const sourceCode = new eslint.SourceCode({
@@ -583,7 +615,7 @@ class Parser extends EventEmitter {
 
         const ast = espree.parse(
             expression,
-            this.getAstParsingOptions()
+            getAstDefaultOptions()
         );
 
         const sourceCode = new eslint.SourceCode({

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -7,7 +7,11 @@ const HtmlParser = require('htmlparser2-svelte').Parser;
 
 const utils = require('./../utils');
 const jsdoc = require('./../jsdoc');
-const { validateFeatures, getAstDefaultOptions } = require('../options');
+const {
+    normalize: normalizeOptions,
+    validateFeatures,
+    getAstDefaultOptions
+} = require('../options');
 
 const hasOwnProperty = utils.hasOwnProperty;
 
@@ -43,19 +47,18 @@ class Parser extends EventEmitter {
 
         Parser.validateOptions(options);
 
+        // External options
+        this.filename = options.filename;
         this.structure = options.structure;
         this.features = options.features;
         this.includeSourceLocations = options.includeSourceLocations;
-        this.componentName = options.componentName;
-        this.filename = options.filename;
-        this.eventsEmitted = options.eventsEmitted;
-        this.defaultMethodVisibility = options.defaultMethodVisibility;
-        this.defaultActionVisibility = options.defaultActionVisibility;
-        this.identifiers = options.identifiers;
-        this.imports = options.imports;
 
-        this.dispatcherConstructorNames = options.dispatcherConstructorNames;
-        this.dispatcherNames = options.dispatcherNames;
+        // Internal properties
+        this.componentName = null;
+        this.eventsEmitted = {};
+        this.imports = {};
+        this.dispatcherConstructorNames = [];
+        this.dispatcherNames = [];
     }
 
     walk() {
@@ -91,46 +94,12 @@ class Parser extends EventEmitter {
     static getDefaultOptions() {
         return {
             includeSourceLocations: true,
-            defaultMethodVisibility: utils.DEFAULT_VISIBILITY,
-            defaultActionVisibility: utils.DEFAULT_VISIBILITY,
             features: [...SUPPORTED_FEATURES],
-            componentName: null,
-            eventsEmitted: {},
-            identifiers: {},
-            imports: {},
-            dispatcherConstructorNames: [],
-            dispatcherNames: [],
         };
     }
 
-    static normalizeOptions(options) {
-        const defaults = Parser.getDefaultOptions();
-
-        Object.keys(defaults).forEach((optionKey) => {
-            // If the key was not set by the user, apply default value.
-            if (!(optionKey in options)) {
-                options[optionKey] = defaults[optionKey];
-            }
-        });
-    }
-
     static validateOptions(options) {
-        Parser.normalizeOptions(options);
-
-        // Check the presence and basic format of multiple options
-        for (const key of ['eventsEmitted', 'identifiers', 'imports']) {
-            const hasKey = (key in options);
-
-            if (!hasKey) {
-                throw new Error(`options.${key} is required`);
-            }
-
-            const hasCorrectType = typeof options[key] === 'object';
-
-            if (!hasCorrectType) {
-                throw new TypeError(`options.${key} must be of type 'object'`);
-            }
-        }
+        normalizeOptions(options, Parser.getDefaultOptions());
 
         validateFeatures(options, SUPPORTED_FEATURES);
     }

--- a/test/integration/parse/parse.spec.js
+++ b/test/integration/parse/parse.spec.js
@@ -3,6 +3,11 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const parser = require('./../../../index');
+const { ParserError } = require('../../../lib/options');
+const { AssertionError } = require('chai');
+const {
+    SUPPORTED_FEATURES: V3_SUPPORTED_FEATURES
+} = require('../../../lib/v3/parser');
 
 describe('parse - Integration', () => {
     it('should correctly auto-detect svelte V2 component', (done) => {
@@ -23,13 +28,30 @@ describe('parse - Integration', () => {
         parser.parse({
             filename: path.resolve(__dirname, 'basicV3.svelte'),
         }).then((doc) => {
-            expect(doc, 'Document should be provided').to.exist;
+            expect(doc, 'Document should exist').to.exist;
             // v3-parser converts component name to PascalCase
             expect(doc.name).to.equal('BasicV3');
 
             done();
         }).catch(e => {
             done(e);
+        });
+    });
+
+    it('should throw when passed unsupported features', (done) => {
+        parser.parse({
+            version: 3,
+            filename: path.resolve(__dirname, 'basicV3.svelte'),
+            features: ['data', 'unsupported'],
+        }).then(() => {
+            done(new AssertionError(
+                'parser.parse should throw ParserError.FeaturesNotSupported'
+            ));
+        }).catch(e => {
+            expect(e.message).is.equal(ParserError.FeaturesNotSupported(
+                ['unsupported'], V3_SUPPORTED_FEATURES
+            ));
+            done();
         });
     });
 });

--- a/test/integration/parse/parse.spec.js
+++ b/test/integration/parse/parse.spec.js
@@ -8,6 +8,9 @@ const { AssertionError } = require('chai');
 const {
     SUPPORTED_FEATURES: V3_SUPPORTED_FEATURES
 } = require('../../../lib/v3/parser');
+const {
+    SUPPORTED_FEATURES: V2_SUPPORTED_FEATURES
+} = require('../../../lib/parser');
 
 describe('parse - Integration', () => {
     it('should correctly auto-detect svelte V2 component', (done) => {
@@ -38,7 +41,26 @@ describe('parse - Integration', () => {
         });
     });
 
-    it('should throw when passed unsupported features', (done) => {
+    it('should throw when svelte V2 parser receives unsupported features', (done) => {
+        parser.parse({
+            version: 2,
+            filename: path.resolve(__dirname, 'basicV2.svelte'),
+            features: ['data', 'unsupported'],
+        }).then(() => {
+            done(new AssertionError(
+                'parser.parse should throw ParserError.FeaturesNotSupported'
+            ));
+        }).catch(e => {
+            expect(e.message).is.equal(ParserError.FeaturesNotSupported(
+                ['unsupported'], V2_SUPPORTED_FEATURES
+            ));
+            done();
+        }).catch(e => {
+            done(e);
+        });
+    });
+
+    it('should throw when svelte V3 parser receives unsupported features', (done) => {
         parser.parse({
             version: 3,
             filename: path.resolve(__dirname, 'basicV3.svelte'),
@@ -52,6 +74,8 @@ describe('parse - Integration', () => {
                 ['unsupported'], V3_SUPPORTED_FEATURES
             ));
             done();
+        }).catch(e => {
+            done(e);
         });
     });
 });

--- a/test/unit/options/options.spec.js
+++ b/test/unit/options/options.spec.js
@@ -58,6 +58,14 @@ describe('Options Module', () => {
                     OptionsError.IgnoredVisibilitiesNotSupported([unsupported])
                 );
             });
+
+            it('includeSourceLocations is not a boolean', () => {
+                const options = { ...baseOptions, includeSourceLocations: 'true' };
+
+                expect(() => validate(options)).to.throw(
+                    OptionsError.IncludeSourceLocationsFormat
+                );
+            });
         });
 
         describe('Should pass when', () => {
@@ -86,6 +94,14 @@ describe('Options Module', () => {
                 };
 
                 expect(() => validate(options)).to.not.throw();
+            });
+
+            it('includeSourceLocations is a boolean', () => {
+                const options1 = { ...baseOptions, includeSourceLocations: false };
+                const options2 = { ...baseOptions, includeSourceLocations: true };
+
+                expect(() => validate(options1)).to.not.throw();
+                expect(() => validate(options2)).to.not.throw();
             });
         });
     });


### PR DESCRIPTION
This is now completed.
- feat(options-v2): Improve options validation for svelte v2 parser
- test(options-v2): Add unit and integration tests for v2 options validation
- feat(options-v3): Improve options validation for svelte v3 parser
- test(options-v3): Add unit and integration tests for v3 options validation
- refactor: move ast options from parsers to lib/options
- refactor(v2-parser): extract function for sourceCode generation