### PR TITLE
#53 refactor v3 parser

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,7 +69,8 @@ const parseComment = (text, defaultVisibility = DEFAULT_VISIBILITY) => {
 /**
  * @param {Node} node
  * @param {SourceCode} sourceCode
- * @param {*} options
+ * @param {{ defaultVisibility: string, useFirst: boolean, useLeading: boolean, useTrailing: boolean }} options
+ * @return {import('../typings').IScopedCommentItem}
  */
 const getCommentFromSourceCode = (node, sourceCode, {
     defaultVisibility = DEFAULT_VISIBILITY,
@@ -481,6 +482,9 @@ const inferTypeFromVariableDeclaration = (variable) => {
     }
 };
 
+/**
+ * @param {import('../typings').IScopedCommentItem} comment
+ */
 const isTopLevelComment = (comment) => {
     return comment.keywords.some((keyword) => keyword.name === 'component');
 };

--- a/lib/v3/events.js
+++ b/lib/v3/events.js
@@ -1,6 +1,15 @@
 const CommonEvent = Object.freeze({
+    /**
+     * Emit the @see {SvelteDataItem} object.
+     */
     DATA: 'data',
+    /**
+     * Emit the @see {SvelteEventItem} object.
+     */
     EVENT: 'event',
+    /**
+     * Emit the global comment @see {IScopedCommentItem} object.
+     */
     GLOBAL_COMMENT: 'global-comment',
 });
 
@@ -19,8 +28,26 @@ const ScriptEvent = Object.freeze({
     IMPORTED_COMPONENT: 'imported-component',
 });
 
+const ParserEvent = Object.freeze({
+    NAME: 'name',
+    DESCRIPTION: 'description',
+    KEYWORDS: 'keywords',
+
+    DATA: 'data',
+    EVENT: 'event',
+    REF: 'ref',
+    SLOT: 'slot',
+    METHOD: 'method',
+    COMPUTED: 'computed',
+    IMPORTED_COMPONENT: 'component',
+
+    FAILURE: 'failure',
+    END: 'end',
+});
+
 module.exports = {
     CommonEvent,
     TemplateEvent,
     ScriptEvent,
+    ParserEvent
 };

--- a/lib/v3/events.js
+++ b/lib/v3/events.js
@@ -1,0 +1,26 @@
+const CommonEvent = Object.freeze({
+    DATA: 'data',
+    EVENT: 'event',
+    GLOBAL_COMMENT: 'global-comment',
+});
+
+const TemplateEvent = Object.freeze({
+    ...CommonEvent,
+    NAME: 'name',
+    REF: 'ref',
+    SLOT: 'slot',
+    EXPRESSION: 'expression',
+});
+
+const ScriptEvent = Object.freeze({
+    ...CommonEvent,
+    METHOD: 'method',
+    COMPUTED: 'computed',
+    IMPORTED_COMPONENT: 'imported-component',
+});
+
+module.exports = {
+    CommonEvent,
+    TemplateEvent,
+    ScriptEvent,
+};

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -114,6 +114,24 @@ class Parser extends EventEmitter {
         }
     }
 
+    /**
+     * @sideEffect mutates `item.locations`.
+     *
+     * Attaches the node's location to the item if requested by the user.
+     *
+     * @param {*} item the item to attach locations to
+     * @param {{ location?: { start: number, end: number } }} node the parsed node containing a location
+     * @param {{ offset: number }} context parse context containing an offset for locations
+     */
+    attachLocationsIfRequired(item, node, context) {
+        if (this.includeSourceLocations && node.location) {
+            item.locations = [{
+                start: node.location.start + context.offset,
+                end: node.location.end + context.offset,
+            }];
+        }
+    }
+
     emitDataItem(variable, parseContext, defaultVisibility, parentComment) {
         const comment = parentComment || utils.getCommentFromSourceCode(variable.node, parseContext.sourceCode, { defaultVisibility });
 
@@ -132,12 +150,7 @@ class Parser extends EventEmitter {
             item.defaultValue = variable.declarator.init.value;
         }
 
-        if (this.includeSourceLocations && variable.location) {
-            item.locations = [{
-                start: variable.location.start + parseContext.offset,
-                end: variable.location.end + parseContext.offset,
-            }];
-        }
+        this.attachLocationsIfRequired(item, variable, parseContext);
 
         updateType(item);
 
@@ -156,12 +169,7 @@ class Parser extends EventEmitter {
             static: parseContext.scopeType === SCOPE_STATIC
         });
 
-        if (this.includeSourceLocations && method.location) {
-            item.locations = [{
-                start: method.location.start + parseContext.offset,
-                end: method.location.end + parseContext.offset
-            }];
-        }
+        this.attachLocationsIfRequired(item, method, parseContext);
 
         this.emit('method', item);
     }
@@ -173,12 +181,7 @@ class Parser extends EventEmitter {
             type: jsdoc.DEFAULT_TYPE
         });
 
-        if (this.includeSourceLocations && computed.location) {
-            item.locations = [{
-                start: computed.location.start + parseContext.offset,
-                end: computed.location.end + parseContext.offset
-            }];
-        }
+        this.attachLocationsIfRequired(item, computed, parseContext);
 
         updateType(item);
 
@@ -190,12 +193,7 @@ class Parser extends EventEmitter {
             name: event.name
         });
 
-        if (this.includeSourceLocations && event.location) {
-            item.locations = [{
-                start: event.location.start + parseContext.offset,
-                end: event.location.end + parseContext.offset
-            }];
-        }
+        this.attachLocationsIfRequired(item, event, parseContext);
 
         this.emit('event', item);
     }
@@ -206,12 +204,7 @@ class Parser extends EventEmitter {
             importPath: component.path,
         });
 
-        if (this.includeSourceLocations && component.location) {
-            item.locations = [{
-                start: component.location.start + parseContext.offset,
-                end: component.location.end + parseContext.offset
-            }];
-        }
+        this.attachLocationsIfRequired(item, component, parseContext);
 
         this.emit('component', item);
     }

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -2,22 +2,15 @@ const EventEmitter = require('events');
 const path = require('path');
 
 const utils = require('./../utils');
-const jsdoc = require('./../jsdoc');
 const {
     normalize: normalizeOptions,
     validateFeatures,
 } = require('../options');
 
-const {
-    parseAndMergeKeywords,
-    updateType
-} = require('./v3-utils');
-
 const TemplateParser = require('./template');
-const { TemplateEvent, ScriptEvent } = require('./events');
+const { TemplateEvent, ScriptEvent, ParserEvent } = require('./events');
 
 const ScriptParser = require('./script');
-const { SCOPE_STATIC } = require('./script');
 
 /**
  * @typedef {import('../../typings').Svelte3Feature} Svelte3Feature
@@ -64,7 +57,7 @@ class Parser extends EventEmitter {
             try {
                 this.__walk();
             } catch (error) {
-                this.emit('failure', error);
+                this.emit(ParserEvent.FAILURE, error);
             }
         });
 
@@ -84,7 +77,7 @@ class Parser extends EventEmitter {
             this.parseTemplate(this.structure.template);
         }
 
-        this.emit('end');
+        this.emit(ParserEvent.END);
     }
 
     static getDefaultOptions() {
@@ -114,112 +107,22 @@ class Parser extends EventEmitter {
         }
 
         if (this.componentName) {
-            this.emit('name', utils.buildCamelCase(this.componentName));
+            this.emit(ParserEvent.NAME, utils.buildCamelCase(this.componentName));
         }
     }
 
     /**
-     * @sideEffect mutates `item.locations`.
-     *
-     * Attaches the node's location to the item if requested by the user.
-     *
-     * @param {*} item the item to attach locations to
-     * @param {{ location?: { start: number, end: number } }} node the parsed node containing a location
-     * @param {{ offset: number }} context parse context containing an offset for locations
+     * @param {import('../../typings').IScopedCommentItem} comment
      */
-    attachLocationsIfRequired(item, node, context) {
-        if (this.includeSourceLocations && node.location) {
-            item.locations = [{
-                start: node.location.start + context.offset,
-                end: node.location.end + context.offset,
-            }];
-        }
-    }
-
-    emitDataItem(variable, parseContext, defaultVisibility, parentComment) {
-        const comment = parentComment || utils.getCommentFromSourceCode(variable.node, parseContext.sourceCode, { defaultVisibility });
-
-        const item = Object.assign({}, comment, {
-            name: variable.name,
-            kind: variable.kind,
-            static: parseContext.scopeType === SCOPE_STATIC,
-            readonly: variable.kind === 'const',
-            type: utils.inferTypeFromVariableDeclaration(variable),
-            importPath: variable.importPath,
-            originalName: variable.originalName,
-            localName: variable.localName
-        });
-
-        if (variable.declarator && variable.declarator.init) {
-            item.defaultValue = variable.declarator.init.value;
-        }
-
-        this.attachLocationsIfRequired(item, variable, parseContext);
-
-        updateType(item);
-
-        this.emit('data', item);
-    }
-
-    emitMethodItem(method, parseContext, defaultVisibility, parentComment) {
-        const comment = parentComment || utils.getCommentFromSourceCode(method.node, parseContext.sourceCode, { defaultVisibility });
-
-        parseAndMergeKeywords(comment.keywords, method);
-
-        const item = Object.assign({}, comment, {
-            name: method.name,
-            params: method.params,
-            return: method.return,
-            static: parseContext.scopeType === SCOPE_STATIC
-        });
-
-        this.attachLocationsIfRequired(item, method, parseContext);
-
-        this.emit('method', item);
-    }
-
-    emitComputedItem(computed, parseContext, defaultVisibility) {
-        const item = Object.assign({}, utils.getCommentFromSourceCode(computed.node, parseContext.sourceCode, { defaultVisibility }), {
-            name: computed.name,
-            static: parseContext.scopeType === SCOPE_STATIC,
-            type: jsdoc.DEFAULT_TYPE
-        });
-
-        this.attachLocationsIfRequired(item, computed, parseContext);
-
-        updateType(item);
-
-        this.emit('computed', item);
-    }
-
-    emitEventItem(event, parseContext) {
-        const item = Object.assign({}, utils.getCommentFromSourceCode(event.node, parseContext.sourceCode, { defaultVisibility: 'public' }), {
-            name: event.name
-        });
-
-        this.attachLocationsIfRequired(item, event, parseContext);
-
-        this.emit('event', item);
-    }
-
-    emitImportedComponentItem(component, parseContext) {
-        const item = Object.assign({}, utils.getCommentFromSourceCode(component.node, parseContext.sourceCode, { defaultVisibility: 'private' }), {
-            name: component.name,
-            importPath: component.path,
-        });
-
-        this.attachLocationsIfRequired(item, component, parseContext);
-
-        this.emit('component', item);
-    }
-
     emitGlobalComment(comment) {
         if (comment && utils.isTopLevelComment(comment)) {
             if (this.features.includes('description')) {
-                this.emit('description', comment.description);
+                this.emit(ParserEvent.DESCRIPTION, comment.description);
             }
 
-            this.emit('keywords', comment.keywords);
+            if (this.features.includes('keywords')) {
+                this.emit(ParserEvent.KEYWORDS, comment.keywords);
+            }
         }
     }
 
@@ -252,7 +155,10 @@ class Parser extends EventEmitter {
             return this.scriptParser;
         }
 
-        this.scriptParser = new ScriptParser();
+        this.scriptParser = new ScriptParser({
+            features: this.features,
+            includeSourceLocations: this.includeSourceLocations
+        });
 
         this.subscribeToScriptParser(this.scriptParser);
 
@@ -275,48 +181,51 @@ class Parser extends EventEmitter {
     }
 
     subscribeToScriptParser(scriptParser) {
-        scriptParser.on(ScriptEvent.COMPUTED, (computed, context, visibility, comment) => {
-            this.emitComputedItem(computed, context, visibility, comment);
+        scriptParser.on(ScriptEvent.COMPUTED, item => {
+            this.emit(ParserEvent.COMPUTED, item);
         });
-        scriptParser.on(ScriptEvent.DATA, (data, context, visibility, comment) => {
-            this.emitDataItem(data, context, visibility, comment);
+        scriptParser.on(ScriptEvent.DATA, item => {
+            this.emit(ParserEvent.DATA, item);
         });
-        scriptParser.on(ScriptEvent.EVENT, (event, context) => {
-            this.emitEventItem(event, context);
+        scriptParser.on(ScriptEvent.EVENT, item => {
+            this.emit(ParserEvent.EVENT, item);
         });
+        scriptParser.on(ScriptEvent.IMPORTED_COMPONENT, item => {
+            this.emit(ParserEvent.IMPORTED_COMPONENT, item);
+        });
+        scriptParser.on(ScriptEvent.METHOD, item => {
+            this.emit(ParserEvent.METHOD, item);
+        });
+
+        // Special cases where more parsing is required
         scriptParser.on(ScriptEvent.GLOBAL_COMMENT, (comment) => {
             this.emitGlobalComment(comment);
-        });
-        scriptParser.on(ScriptEvent.IMPORTED_COMPONENT, (component, context) => {
-            this.emitImportedComponentItem(component, context);
-        });
-        scriptParser.on(ScriptEvent.METHOD, (method, context, visibility, comment) => {
-            this.emitMethodItem(method, context, visibility, comment);
         });
     }
 
     subscribeToTemplateParser(templateParser) {
         // Forward emit of basic template events
-        templateParser.on(TemplateEvent.DATA, (dataItem) => {
-            this.emit('data', dataItem);
+        templateParser.on(TemplateEvent.DATA, dataItem => {
+            this.emit(ParserEvent.DATA, dataItem);
         });
-        templateParser.on(TemplateEvent.EVENT, (event) => {
-            this.emit('event', event);
+        templateParser.on(TemplateEvent.EVENT, event => {
+            this.emit(ParserEvent.EVENT, event);
         });
-        templateParser.on(TemplateEvent.NAME, (name) => {
-            this.emit('name', name);
+        templateParser.on(TemplateEvent.NAME, name => {
+            this.emit(ParserEvent.NAME, name);
         });
-        templateParser.on(TemplateEvent.REF, (refItem) => {
-            this.emit('ref', refItem);
+        templateParser.on(TemplateEvent.REF, refItem => {
+            this.emit(ParserEvent.REF, refItem);
         });
-        templateParser.on(TemplateEvent.SLOT, (slot) => {
-            this.emit('slot', slot);
+        templateParser.on(TemplateEvent.SLOT, slot => {
+            this.emit(ParserEvent.SLOT, slot);
         });
 
         // Special cases where more parsing is required
         templateParser.on(TemplateEvent.EXPRESSION, (expression) => {
             this.parseTemplateJavascriptExpression(expression);
         });
+
         templateParser.on(TemplateEvent.GLOBAL_COMMENT, (comment) => {
             this.emitGlobalComment(comment);
         });

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -222,8 +222,8 @@ class Parser extends EventEmitter {
     parseScriptBlocks(scripts) {
         const scriptParser = new ScriptParser(scripts);
 
-        scriptParser.on('computed', (method, context, visibility, comment) => {
-            this.emitComputedItem(method, context, visibility, comment);
+        scriptParser.on('computed', (computed, context, visibility, comment) => {
+            this.emitComputedItem(computed, context, visibility, comment);
         });
         scriptParser.on('data', (data, context, visibility, comment) => {
             this.emitDataItem(data, context, visibility, comment);
@@ -275,6 +275,8 @@ class Parser extends EventEmitter {
         });
 
         templateParser.parse();
+
+        return templateParser;
     }
 
     parseTemplateJavascriptExpression(expression) {

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -3,7 +3,6 @@ const path = require('path');
 
 const espree = require('espree');
 const eslint = require('eslint');
-const HtmlParser = require('htmlparser2-svelte').Parser;
 
 const utils = require('./../utils');
 const jsdoc = require('./../jsdoc');
@@ -20,6 +19,9 @@ const {
     updateType
 } = require('./v3-utils');
 
+const TemplateParser = require('./template');
+const TemplateEvent = require('./template').TemplateEvent;
+
 const hasOwnProperty = utils.hasOwnProperty;
 
 const SUPPORTED_FEATURES = [
@@ -34,9 +36,12 @@ const SUPPORTED_FEATURES = [
     'slots',
     'refs'
 ];
+
 const SCOPE_DEFAULT = 'default';
 const SCOPE_STATIC = 'static';
 const SCOPE_MARKUP = 'markup';
+
+const RE_ANONYMOUS_FUNCTION = /^{?\s*function\s+\(/i;
 
 class Parser extends EventEmitter {
     constructor(options) {
@@ -204,14 +209,6 @@ class Parser extends EventEmitter {
         }
 
         this.emit('event', item);
-    }
-
-    emitRefItem(ref) {
-        const item = Object.assign({}, ref, {
-            visibility: 'private'
-        });
-
-        this.emit('ref', item);
     }
 
     emitImportedComponentItem(component, parseContext) {
@@ -561,18 +558,11 @@ class Parser extends EventEmitter {
         this.parseBodyRecursively(ast, scriptParseContext, 0);
     }
 
-    parseMarkupExpressionBlock(expression, offset) {
+    parseTemplateJavascriptExpression(expression, offset) {
         // Add name for anonymous functions to prevent parser error
-        const regex = /^{?\s*function\s+\(/i;
-
-        expression = expression.replace(regex, function (m) {
-            // When quotes in attributes used curly braces are provided here,
-            // so we should handle it separately
-            if (m.startsWith('{')) {
-                return '{function a(';
-            }
-
-            return 'function a(';
+        expression = expression.replace(RE_ANONYMOUS_FUNCTION, function (m) {
+            // Preserve the curly brace if it appears in the quotes
+            return m.startsWith('{') ? '{function a(' : 'function a(';
         });
 
         const ast = espree.parse(
@@ -586,7 +576,7 @@ class Parser extends EventEmitter {
         });
 
         const scriptParseContext = {
-            scope: SCOPE_MARKUP,
+            // scope: SCOPE_MARKUP, // TODO: This is not used. SCOPE_TYPE instead
             offset: offset,
             sourceCode: sourceCode
         };
@@ -631,190 +621,34 @@ class Parser extends EventEmitter {
     }
 
     parseTemplate() {
-        let rootElementIndex = 0;
-        let lastComment = null;
-        let lastAttributeIndex = 0;
-        let lastAttributeLocations = {};
-        let lastTagName = null;
+        const templateParser = new TemplateParser(this);
 
-        const parser = new HtmlParser({
-            oncomment: (data) => {
-                lastComment = data.trim();
-            },
-            ontext: (text) => {
-                if (text.trim()) {
-                    lastComment = null;
-                }
-            },
-            onattribute: (name, value) => {
-                if (this.includeSourceLocations && parser.startIndex >= 0 && parser.endIndex >= parser.startIndex) {
-                    lastAttributeLocations[name] = {
-                        start: lastAttributeIndex,
-                        end: parser._tokenizer._index
-                    };
-
-                    lastAttributeIndex = parser._tokenizer._index;
-                }
-
-                if (this.features.includes('events')) {
-                    if (lastTagName !== 'slot') {
-                        // Expose events that propagated from child events
-                        // Handle event syntax like ```<button on:click>Some link</button>```
-                        if (name.length > 3 && name.indexOf('on:') === 0 && !value) {
-                            const nameWithModificators = name.substr(3).split('|');
-
-                            const baseEvent = {
-                                name: nameWithModificators[0],
-                                parent: lastTagName,
-                                modificators: nameWithModificators.slice(1),
-                                locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
-                                    ? [lastAttributeLocations[name]]
-                                    : null
-                            };
-
-                            if (lastComment) {
-                                lastComment = `/** ${lastComment} */`;
-                            }
-
-                            const comment = utils.parseComment(lastComment || '');
-
-                            baseEvent.visibility = comment.visibility;
-                            baseEvent.description = comment.description || '';
-                            baseEvent.keywords = comment.keywords;
-
-                            if (!hasOwnProperty(this.eventsEmitted, baseEvent.name)) {
-                                this.eventsEmitted[baseEvent.name] = baseEvent;
-
-                                parseAndMergeKeywords(comment.keywords, baseEvent);
-
-                                this.emit('event', baseEvent);
-                            }
-
-                            lastComment = null;
-                        }
-
-                        // Parse event handlers
-                        if (name.length > 3 && name.indexOf('on:') === 0 && value) {
-                            this.parseMarkupExpressionBlock(value);
-                        }
-                    }
-                }
-            },
-            onopentagname: (tagName) => {
-                lastTagName = tagName;
-                lastAttributeIndex = parser._tokenizer._index;
-                lastAttributeLocations = {};
-            },
-            onopentag: (tagName, attrs) => {
-                const isNotStyleOrScript = !['style', 'script'].includes(tagName);
-                const isTopLevelElement = parser._stack.length === 1;
-
-                if (isTopLevelElement && isNotStyleOrScript) {
-                    if (lastComment && rootElementIndex === 0) {
-                        this.emitGlobalComment(utils.parseComment(lastComment));
-                    }
-
-                    rootElementIndex += 1;
-                }
-
-                if (tagName === 'slot') {
-                    if (this.features.includes('slots')) {
-                        const exposedParameters = Object.keys(attrs)
-                            .filter(name => name.length > 0 && name !== 'name')
-                            .map(name => ({
-                                name: name,
-                                visibility: 'public'
-                            }));
-
-                        const slot = {
-                            name: attrs.name || 'default',
-                            description: lastComment,
-                            visibility: 'public',
-                            parameters: exposedParameters
-                        };
-
-                        if (this.includeSourceLocations && parser.startIndex >= 0 && parser.endIndex >= parser.startIndex) {
-                            slot.loc = {
-                                start: parser.startIndex,
-                                end: parser.endIndex
-                            };
-                        }
-
-                        this.emit('slot', slot);
-                    }
-                } else {
-                    if (tagName === 'svelte:options' && attrs.tag) {
-                        if (this.features.includes('name')) {
-                            this.emit('name', attrs.tag);
-                        }
-                    }
-
-                    if (this.features.includes('data')) {
-                        const bindProperties = Object.keys(attrs)
-                            .filter(name => name.length > 5 && name.indexOf('bind:') === 0)
-                            .filter(name => name !== 'bind:this')
-                            .map(name => {
-                                const sourcePropertyName = name.substr(5);
-
-                                let targetPropertyName = sourcePropertyName;
-
-                                const attributeValue = attrs[name];
-
-                                if (attributeValue && attributeValue.length > 0) {
-                                    targetPropertyName = attributeValue;
-                                }
-
-                                return {
-                                    sourcePropertyName: sourcePropertyName,
-                                    targetPropertyName: targetPropertyName,
-                                    parent: tagName,
-                                    locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
-                                        ? [lastAttributeLocations[name]]
-                                        : null
-                                };
-                            });
-
-                        bindProperties.forEach(bindProperty => {
-                            const dataItem = {
-                                name: bindProperty.targetPropertyName,
-                                kind: undefined,
-                                bind: [{
-                                    source: bindProperty.parent,
-                                    property: bindProperty.sourcePropertyName
-                                }],
-                                locations: bindProperty.locations,
-                                visibility: 'private',
-                                static: false,
-                                readonly: false
-                            };
-
-                            this.emit('data', dataItem);
-                        });
-                    }
-
-                    if (this.features.includes('refs')) {
-                        if (hasOwnProperty(attrs, 'bind:this') && attrs['bind:this']) {
-                            const bindedVariableName = attrs['bind:this'];
-
-                            this.emitRefItem({
-                                name: bindedVariableName,
-                                parent: tagName,
-                                locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, 'bind:this')
-                                    ? [lastAttributeLocations['bind:this']]
-                                    : null
-                            });
-                        }
-                    }
-                }
-            }
-        }, {
-            lowerCaseTags: false,
-            lowerCaseAttributeNames: false,
-            curlyBracesInAttributes: true
+        // Forward emit of basic template events
+        templateParser.on(TemplateEvent.DATA, (dataItem) => {
+            this.emit('data', dataItem);
+        });
+        templateParser.on(TemplateEvent.EVENT, (event) => {
+            this.emit('event', event);
+        });
+        templateParser.on(TemplateEvent.NAME, (name) => {
+            this.emit('name', name);
+        });
+        templateParser.on(TemplateEvent.REF, (refItem) => {
+            this.emit('ref', refItem);
+        });
+        templateParser.on(TemplateEvent.SLOT, (slot) => {
+            this.emit('slot', slot);
         });
 
-        parser.write(this.structure.template);
-        parser.end();
+        // Special cases where more parsing is required
+        templateParser.on(TemplateEvent.EXPRESSION, (expression) => {
+            this.parseTemplateJavascriptExpression(expression);
+        });
+        templateParser.on(TemplateEvent.GLOBAL_COMMENT, (comment) => {
+            this.emitGlobalComment(comment);
+        });
+
+        templateParser.parse();
     }
 }
 

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -72,7 +72,7 @@ class Parser extends EventEmitter {
             this.parseComponentName();
         }
 
-        if (this.structure.scripts?.length) {
+        if (this.structure.scripts && this.structure.scripts.length) {
             this.scriptParser = this.parseScriptBlocks(this.structure.scripts);
         }
 

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -14,11 +14,15 @@ const {
 } = require('./v3-utils');
 
 const TemplateParser = require('./template');
-const { TemplateEvent } = require('./template');
+const { TemplateEvent, ScriptEvent } = require('./events');
 
 const ScriptParser = require('./script');
 const { SCOPE_STATIC } = require('./script');
 
+/**
+ * @typedef {import('../../typings').Svelte3Feature} Svelte3Feature
+ * @type {Svelte3Feature[]}
+*/
 const SUPPORTED_FEATURES = [
     'name',
     'data',
@@ -31,8 +35,6 @@ const SUPPORTED_FEATURES = [
     'slots',
     'refs'
 ];
-
-const RE_ANONYMOUS_FUNCTION = /^{?\s*function\s+\(/i;
 
 class Parser extends EventEmitter {
     /**
@@ -52,7 +54,9 @@ class Parser extends EventEmitter {
 
         // Internal properties
         this.componentName = null;
+
         this.scriptParser = null;
+        this.templateParser = null;
     }
 
     walk() {
@@ -73,11 +77,11 @@ class Parser extends EventEmitter {
         }
 
         if (this.structure.scripts && this.structure.scripts.length) {
-            this.scriptParser = this.parseScriptBlocks(this.structure.scripts);
+            this.parseScriptBlocks(this.structure.scripts);
         }
 
         if (this.structure.template) {
-            this.parseTemplate();
+            this.parseTemplate(this.structure.template);
         }
 
         this.emit('end');
@@ -220,35 +224,78 @@ class Parser extends EventEmitter {
     }
 
     parseScriptBlocks(scripts) {
-        const scriptParser = new ScriptParser(scripts);
+        const scriptParser = this.buildScriptParser();
 
-        scriptParser.on('computed', (computed, context, visibility, comment) => {
-            this.emitComputedItem(computed, context, visibility, comment);
-        });
-        scriptParser.on('data', (data, context, visibility, comment) => {
-            this.emitDataItem(data, context, visibility, comment);
-        });
-        scriptParser.on('event', (event, context) => {
-            this.emitEventItem(event, context);
-        });
-        scriptParser.on('global-comment', (comment) => {
-            this.emitGlobalComment(comment);
-        });
-        scriptParser.on('imported-component', (component, context) => {
-            this.emitImportedComponentItem(component, context);
-        });
-        scriptParser.on('method', (method, context, visibility, comment) => {
-            this.emitMethodItem(method, context, visibility, comment);
-        });
-
-        scriptParser.parse();
+        scriptParser.parse(scripts);
 
         return scriptParser;
     }
 
-    parseTemplate() {
-        const templateParser = new TemplateParser(this);
+    parseTemplateJavascriptExpression(expression) {
+        const scriptParser = this.buildScriptParser();
 
+        scriptParser.parseScriptExpression(expression);
+
+        return scriptParser;
+    }
+
+    parseTemplate(template) {
+        const templateParser = this.buildTemplateParser();
+
+        templateParser.parse(template);
+
+        return templateParser;
+    }
+
+    buildScriptParser() {
+        if (this.scriptParser) {
+            return this.scriptParser;
+        }
+
+        this.scriptParser = new ScriptParser();
+
+        this.subscribeToScriptParser(this.scriptParser);
+
+        return this.scriptParser;
+    }
+
+    buildTemplateParser() {
+        if (this.templateParser) {
+            return this.templateParser;
+        }
+
+        this.templateParser = new TemplateParser({
+            features: this.features,
+            includeSourceLocations: this.includeSourceLocations
+        });
+
+        this.subscribeToTemplateParser(this.templateParser);
+
+        return this.templateParser;
+    }
+
+    subscribeToScriptParser(scriptParser) {
+        scriptParser.on(ScriptEvent.COMPUTED, (computed, context, visibility, comment) => {
+            this.emitComputedItem(computed, context, visibility, comment);
+        });
+        scriptParser.on(ScriptEvent.DATA, (data, context, visibility, comment) => {
+            this.emitDataItem(data, context, visibility, comment);
+        });
+        scriptParser.on(ScriptEvent.EVENT, (event, context) => {
+            this.emitEventItem(event, context);
+        });
+        scriptParser.on(ScriptEvent.GLOBAL_COMMENT, (comment) => {
+            this.emitGlobalComment(comment);
+        });
+        scriptParser.on(ScriptEvent.IMPORTED_COMPONENT, (component, context) => {
+            this.emitImportedComponentItem(component, context);
+        });
+        scriptParser.on(ScriptEvent.METHOD, (method, context, visibility, comment) => {
+            this.emitMethodItem(method, context, visibility, comment);
+        });
+    }
+
+    subscribeToTemplateParser(templateParser) {
         // Forward emit of basic template events
         templateParser.on(TemplateEvent.DATA, (dataItem) => {
             this.emit('data', dataItem);
@@ -273,20 +320,6 @@ class Parser extends EventEmitter {
         templateParser.on(TemplateEvent.GLOBAL_COMMENT, (comment) => {
             this.emitGlobalComment(comment);
         });
-
-        templateParser.parse();
-
-        return templateParser;
-    }
-
-    parseTemplateJavascriptExpression(expression) {
-        // Add name for anonymous functions to prevent parser error
-        expression = expression.replace(RE_ANONYMOUS_FUNCTION, function (m) {
-            // Preserve the curly brace if it appears in the quotes
-            return m.startsWith('{') ? '{function a(' : 'function a(';
-        });
-
-        this.scriptParser.parseJavascriptExpression(expression);
     }
 }
 

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -1,28 +1,23 @@
 const EventEmitter = require('events');
 const path = require('path');
 
-const espree = require('espree');
-const eslint = require('eslint');
-
 const utils = require('./../utils');
 const jsdoc = require('./../jsdoc');
 const {
     normalize: normalizeOptions,
     validateFeatures,
-    getAstDefaultOptions
 } = require('../options');
 
 const {
-    parseFunctionDeclaration,
-    parseVariableDeclaration,
     parseAndMergeKeywords,
     updateType
 } = require('./v3-utils');
 
 const TemplateParser = require('./template');
-const TemplateEvent = require('./template').TemplateEvent;
+const { TemplateEvent } = require('./template');
 
-const hasOwnProperty = utils.hasOwnProperty;
+const ScriptParser = require('./script');
+const { SCOPE_STATIC } = require('./script');
 
 const SUPPORTED_FEATURES = [
     'name',
@@ -37,13 +32,12 @@ const SUPPORTED_FEATURES = [
     'refs'
 ];
 
-const SCOPE_DEFAULT = 'default';
-const SCOPE_STATIC = 'static';
-const SCOPE_MARKUP = 'markup';
-
 const RE_ANONYMOUS_FUNCTION = /^{?\s*function\s+\(/i;
 
 class Parser extends EventEmitter {
+    /**
+     * @param {import('../options').SvelteParserOptions} options
+     */
     constructor(options) {
         super();
 
@@ -51,17 +45,14 @@ class Parser extends EventEmitter {
 
         // External options
         this.filename = options.filename;
-        this.structure = options.structure;
         this.features = options.features;
         this.includeSourceLocations = options.includeSourceLocations;
+        /** @type {import("../helpers").FileStructure} */
+        this.structure = options.structure;
 
         // Internal properties
         this.componentName = null;
-        this.eventsEmitted = {};
-        this.identifiers = {};
-        this.imports = {};
-        this.dispatcherConstructorNames = [];
-        this.dispatcherNames = [];
+        this.scriptParser = null;
     }
 
     walk() {
@@ -81,10 +72,8 @@ class Parser extends EventEmitter {
             this.parseComponentName();
         }
 
-        if (this.structure.scripts) {
-            this.structure.scripts.forEach(scriptBlock => {
-                this.parseScriptBlock(scriptBlock);
-            });
+        if (this.structure.scripts?.length) {
+            this.scriptParser = this.parseScriptBlocks(this.structure.scripts);
         }
 
         if (this.structure.template) {
@@ -237,387 +226,31 @@ class Parser extends EventEmitter {
         }
     }
 
-    parseBodyRecursively(rootNode, parseContext, level) {
-        const nodes = rootNode.body
-            ? rootNode.body
-            : (rootNode.length > 0 ? rootNode : [rootNode]);
+    parseScriptBlocks(scripts) {
+        const scriptParser = new ScriptParser(scripts);
 
-        nodes.forEach((node, index) => {
-            if (index === 0 && level === 0) {
-                const firstComment = utils.getCommentFromSourceCode(node, parseContext.sourceCode, { useTrailing: false, useFirst: true });
-
-                this.emitGlobalComment(firstComment);
-            }
-
-            if (node.type === 'BlockStatement') {
-                this.parseBodyRecursively(node.body, parseContext, level);
-
-                return;
-            }
-
-            if (node.type === 'ExpressionStatement') {
-                const expressionNode = node.expression;
-
-                if (expressionNode.type === 'CallExpression') {
-                    const callee = expressionNode.callee;
-
-                    if (expressionNode.arguments) {
-                        this.parseBodyRecursively(expressionNode.arguments, parseContext, level + 1);
-                    }
-
-                    if (callee.type === 'Identifier' && this.dispatcherNames.indexOf(callee.name) >= 0) {
-                        const eventItem = this.parseEventDeclaration(expressionNode);
-
-                        this.emitEventItem(eventItem, parseContext);
-
-                        return;
-                    }
-                }
-
-                if (expressionNode.type === 'ArrowFunctionExpression') {
-                    if (expressionNode.body) {
-                        this.parseBodyRecursively(expressionNode.body, parseContext, level + 1);
-
-                        return;
-                    }
-                }
-            }
-
-            if (node.type === 'CallExpression') {
-                const callee = node.callee;
-
-                if (node.arguments) {
-                    this.parseBodyRecursively(node.arguments, parseContext, level + 1);
-                }
-
-                if (callee.type === 'Identifier' && this.dispatcherNames.includes(callee.name)) {
-                    const eventItem = this.parseEventDeclaration(node);
-
-                    this.emitEventItem(eventItem, parseContext);
-
-                    return;
-                }
-            }
-
-            if (node.type === 'VariableDeclaration' && parseContext.scopeType !== SCOPE_MARKUP) {
-                const variables = parseVariableDeclaration(node);
-
-                variables.forEach(variable => {
-                    if (level === 0) {
-                        this.emitDataItem(variable, parseContext, 'private');
-                    }
-
-                    if (variable.declarator.init) {
-                        const idNode = variable.declarator.id;
-                        const initNode = variable.declarator.init;
-
-                        // Store top level variables in 'identifiers'
-                        if (level === 0 && idNode.type === 'Identifier') {
-                            this.identifiers[idNode.name] = variable.declarator.init;
-                        }
-
-                        if (initNode.type === 'CallExpression') {
-                            const callee = initNode.callee;
-
-                            if (initNode.arguments) {
-                                this.parseBodyRecursively(initNode.arguments, parseContext, level + 1);
-                            }
-
-                            if (callee.type === 'Identifier' && this.dispatcherConstructorNames.includes(callee.name)) {
-                                this.dispatcherNames.push(variable.name);
-                            }
-                        } else if (initNode.type === 'ArrowFunctionExpression') {
-                            if (initNode.body) {
-                                this.parseBodyRecursively(initNode.body, parseContext, level + 1);
-                            }
-                        }
-                    }
-                });
-
-                return;
-            }
-
-            if (node.type === 'FunctionDeclaration') {
-                this.emitMethodItem(parseFunctionDeclaration(node), parseContext, 'private');
-
-                if (node.body) {
-                    this.parseBodyRecursively(node.body, parseContext, level + 1);
-                }
-
-                return;
-            }
-
-            if (node.type === 'ExportNamedDeclaration' && level === 0 && parseContext.scopeType !== SCOPE_MARKUP) {
-                const declaration = node.declaration;
-                const specifiers = node.specifiers;
-
-                if (declaration) {
-                    const exportNodeComment = utils.getCommentFromSourceCode(node, parseContext.sourceCode, { defaultVisibility: 'public', useLeading: true, useTrailing: false });
-
-                    if (declaration.type === 'VariableDeclaration') {
-                        const variables = parseVariableDeclaration(declaration);
-
-                        variables.forEach(variable => {
-                            this.emitDataItem(variable, parseContext, 'public', exportNodeComment);
-
-                            if (variable.declarator.init) {
-                                const initNode = variable.declarator.init;
-
-                                if (initNode.type === 'CallExpression') {
-                                    const callee = initNode.callee;
-
-                                    if (initNode.arguments) {
-                                        this.parseBodyRecursively(initNode.arguments, parseContext, level + 1);
-                                    }
-
-                                    if (callee.type === 'Identifier' && this.dispatcherConstructorNames.includes(callee.name)) {
-                                        this.dispatcherNames.push(variable.name);
-                                    }
-                                } else if (initNode.type === 'ArrowFunctionExpression') {
-                                    if (initNode.body) {
-                                        this.parseBodyRecursively(initNode.body, parseContext, level + 1);
-                                    }
-                                }
-                            }
-                        });
-
-                        return;
-                    }
-
-                    if (declaration.type === 'FunctionDeclaration') {
-                        const func = parseFunctionDeclaration(declaration);
-
-                        this.emitMethodItem(func, parseContext, 'public', exportNodeComment);
-
-                        if (declaration.body) {
-                            this.parseBodyRecursively(declaration.body, parseContext, level + 1);
-                        }
-
-                        return;
-                    }
-                }
-
-                if (specifiers) {
-                    specifiers.forEach(specifier => {
-                        if (specifier.type === 'ExportSpecifier') {
-                            const exportedOrLocalName = specifier.exported
-                                ? specifier.exported.name
-                                : specifier.local.name;
-
-                            this.emitDataItem({
-                                node: specifier,
-                                name: exportedOrLocalName,
-                                localName: specifier.local.name,
-                                kind: 'const',
-                                location: {
-                                    start: specifier.exported ? specifier.exported.start : specifier.local.start,
-                                    end: specifier.exported ? specifier.exported.end : specifier.local.end
-                                }
-                            }, parseContext, 'public');
-                        }
-                    });
-                }
-            }
-
-            if (node.type === 'LabeledStatement' && level === 0 && parseContext.scopeType !== SCOPE_MARKUP) {
-                const idNode = node.label;
-
-                if (idNode && idNode.type === 'Identifier' && idNode.name === '$') {
-                    if (node.body && node.body.type === 'ExpressionStatement') {
-                        const expression = node.body.expression;
-
-                        if (expression && expression.type === 'AssignmentExpression') {
-                            const leftNode = expression.left;
-
-                            if (leftNode.type === 'Identifier') {
-                                this.emitComputedItem({
-                                    name: leftNode.name,
-                                    location: {
-                                        start: leftNode.start,
-                                        end: leftNode.end
-                                    },
-                                    node: node
-                                }, parseContext, 'private');
-
-                                return;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (node.type === 'ImportDeclaration' && level === 0 && parseContext.scopeType !== SCOPE_MARKUP) {
-                const specifier = node.specifiers[0];
-                const source = node.source;
-
-                if (source && source.type === 'Literal') {
-                    const sourceFileName = source.value;
-
-                    if (specifier && specifier.type === 'ImportDefaultSpecifier') {
-                        const importEntry = {
-                            identifier: specifier.local.name,
-                            sourceFilename: sourceFileName
-                        };
-
-                        if (!hasOwnProperty(this.imports, importEntry.identifier)) {
-                            this.imports[importEntry.identifier] = importEntry;
-
-                            if (importEntry.identifier) {
-                                if (importEntry.identifier[0] === importEntry.identifier[0].toUpperCase()) {
-                                    const component = {
-                                        node: node,
-                                        name: importEntry.identifier,
-                                        path: importEntry.sourceFilename,
-                                        location: {
-                                            start: specifier.local.start,
-                                            end: specifier.local.end
-                                        }
-                                    };
-
-                                    this.emitImportedComponentItem(component, parseContext);
-
-                                    return;
-                                } else {
-                                    const imported = specifier.imported
-                                        ? specifier.imported.name
-                                        : undefined;
-
-                                    this.emitDataItem({
-                                        node,
-                                        name: importEntry.identifier,
-                                        originalName: imported || importEntry.identifier,
-                                        importPath: importEntry.sourceFilename,
-                                        kind: 'const',
-                                        location: {
-                                            start: specifier.local.start,
-                                            end: specifier.local.end
-                                        }
-                                    }, parseContext, 'private');
-                                }
-                            }
-                        }
-                    } else if (node.specifiers.length > 0) {
-                        node.specifiers.forEach((specifier) => {
-                            if (specifier.type === 'ImportSpecifier') {
-                                this.emitDataItem({
-                                    node: specifier,
-                                    name: specifier.local.name,
-                                    originalName: specifier.imported
-                                        ? specifier.imported.name
-                                        : specifier.local.name,
-                                    importPath: sourceFileName,
-                                    kind: 'const',
-                                    location: {
-                                        start: specifier.local.start,
-                                        end: specifier.local.end
-                                    }
-                                }, parseContext, 'private');
-                            }
-                        });
-                    }
-
-                    // Import svelte API functions
-                    if (sourceFileName === 'svelte') {
-                        // Dispatcher constructors
-                        node.specifiers
-                            .filter(specifier => specifier.imported.name === 'createEventDispatcher')
-                            .forEach(specifier => {
-                                this.dispatcherConstructorNames.push(specifier.local.name);
-                            });
-                    }
-                }
-            }
-
-            if (node.body) {
-                this.parseBodyRecursively(node.body, parseContext, level + 1);
-            }
+        scriptParser.on('computed', (method, context, visibility, comment) => {
+            this.emitComputedItem(method, context, visibility, comment);
         });
-    }
-
-    parseScriptBlock(scriptBlock) {
-        const ast = espree.parse(
-            scriptBlock.content,
-            getAstDefaultOptions()
-        );
-
-        const sourceCode = new eslint.SourceCode({
-            text: scriptBlock.content,
-            ast: ast
+        scriptParser.on('data', (data, context, visibility, comment) => {
+            this.emitDataItem(data, context, visibility, comment);
+        });
+        scriptParser.on('event', (event, context) => {
+            this.emitEventItem(event, context);
+        });
+        scriptParser.on('global-comment', (comment) => {
+            this.emitGlobalComment(comment);
+        });
+        scriptParser.on('imported-component', (component, context) => {
+            this.emitImportedComponentItem(component, context);
+        });
+        scriptParser.on('method', (method, context, visibility, comment) => {
+            this.emitMethodItem(method, context, visibility, comment);
         });
 
-        const isStaticScope = /\sscope=('module'|"module")/gi.test(scriptBlock.attributes);
+        scriptParser.parse();
 
-        const scriptParseContext = {
-            scopeType: isStaticScope
-                ? SCOPE_STATIC
-                : SCOPE_DEFAULT,
-            offset: scriptBlock.offset,
-            sourceCode: sourceCode
-        };
-
-        this.parseBodyRecursively(ast, scriptParseContext, 0);
-    }
-
-    parseTemplateJavascriptExpression(expression, offset) {
-        // Add name for anonymous functions to prevent parser error
-        expression = expression.replace(RE_ANONYMOUS_FUNCTION, function (m) {
-            // Preserve the curly brace if it appears in the quotes
-            return m.startsWith('{') ? '{function a(' : 'function a(';
-        });
-
-        const ast = espree.parse(
-            expression,
-            getAstDefaultOptions()
-        );
-
-        const sourceCode = new eslint.SourceCode({
-            text: expression,
-            ast: ast
-        });
-
-        const scriptParseContext = {
-            // scope: SCOPE_MARKUP, // TODO: This is not used. SCOPE_TYPE instead
-            offset: offset,
-            sourceCode: sourceCode
-        };
-
-        this.parseBodyRecursively(ast, scriptParseContext, 0);
-    }
-
-    parseEventDeclaration(node) {
-        if (node.type !== 'CallExpression') {
-            throw new Error('Node should have a CallExpressionType, but is ' + node.type);
-        }
-
-        const args = node.arguments;
-
-        if (!args || !args.length) {
-            return null;
-        }
-
-        const nameNode = args[0];
-
-        let name;
-
-        try {
-            const chain = utils.buildPropertyAccessorChainFromAst(nameNode);
-
-            // This function can throw if chain is not valid
-            name = utils.getValueForPropertyAccessorChain(this.identifiers, chain);
-        } catch (error) {
-            name = nameNode.type === 'Literal'
-                ? nameNode.value
-                : undefined;
-        }
-
-        return {
-            name: name,
-            node: node,
-            location: {
-                start: nameNode.start,
-                end: nameNode.end
-            }
-        };
+        return scriptParser;
     }
 
     parseTemplate() {
@@ -649,6 +282,16 @@ class Parser extends EventEmitter {
         });
 
         templateParser.parse();
+    }
+
+    parseTemplateJavascriptExpression(expression) {
+        // Add name for anonymous functions to prevent parser error
+        expression = expression.replace(RE_ANONYMOUS_FUNCTION, function (m) {
+            // Preserve the curly brace if it appears in the quotes
+            return m.startsWith('{') ? '{function a(' : 'function a(';
+        });
+
+        this.scriptParser.parseJavascriptExpression(expression);
     }
 }
 

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -208,8 +208,8 @@ class Parser extends EventEmitter {
         templateParser.on(TemplateEvent.DATA, dataItem => {
             this.emit(ParserEvent.DATA, dataItem);
         });
-        templateParser.on(TemplateEvent.EVENT, event => {
-            this.emit(ParserEvent.EVENT, event);
+        templateParser.on(TemplateEvent.EVENT, eventItem => {
+            this.emit(ParserEvent.EVENT, eventItem);
         });
         templateParser.on(TemplateEvent.NAME, name => {
             this.emit(ParserEvent.NAME, name);
@@ -217,15 +217,14 @@ class Parser extends EventEmitter {
         templateParser.on(TemplateEvent.REF, refItem => {
             this.emit(ParserEvent.REF, refItem);
         });
-        templateParser.on(TemplateEvent.SLOT, slot => {
-            this.emit(ParserEvent.SLOT, slot);
+        templateParser.on(TemplateEvent.SLOT, slotItem => {
+            this.emit(ParserEvent.SLOT, slotItem);
         });
 
         // Special cases where more parsing is required
         templateParser.on(TemplateEvent.EXPRESSION, (expression) => {
             this.parseTemplateJavascriptExpression(expression);
         });
-
         templateParser.on(TemplateEvent.GLOBAL_COMMENT, (comment) => {
             this.emitGlobalComment(comment);
         });

--- a/lib/v3/parser.js
+++ b/lib/v3/parser.js
@@ -13,6 +13,13 @@ const {
     getAstDefaultOptions
 } = require('../options');
 
+const {
+    parseFunctionDeclaration,
+    parseVariableDeclaration,
+    parseAndMergeKeywords,
+    updateType
+} = require('./v3-utils');
+
 const hasOwnProperty = utils.hasOwnProperty;
 
 const SUPPORTED_FEATURES = [
@@ -30,16 +37,6 @@ const SUPPORTED_FEATURES = [
 const SCOPE_DEFAULT = 'default';
 const SCOPE_STATIC = 'static';
 const SCOPE_MARKUP = 'markup';
-
-const PARAM_ALIASES = {
-    arg: true,
-    argument: true,
-    param: true
-};
-const RETURN_ALIASES = {
-    return: true,
-    returns: true,
-};
 
 class Parser extends EventEmitter {
     constructor(options) {
@@ -123,18 +120,6 @@ class Parser extends EventEmitter {
         }
     }
 
-    updateType(item) {
-        const typeKeyword = item.keywords.find(kw => kw.name === 'type');
-
-        if (typeKeyword) {
-            const parsedType = jsdoc.parseTypeKeyword(typeKeyword.description);
-
-            if (parsedType) {
-                item.type = parsedType;
-            }
-        }
-    }
-
     emitDataItem(variable, parseContext, defaultVisibility, parentComment) {
         const comment = parentComment || utils.getCommentFromSourceCode(variable.node, parseContext.sourceCode, { defaultVisibility });
 
@@ -160,7 +145,7 @@ class Parser extends EventEmitter {
             }];
         }
 
-        this.updateType(item);
+        updateType(item);
 
         this.emit('data', item);
     }
@@ -168,7 +153,7 @@ class Parser extends EventEmitter {
     emitMethodItem(method, parseContext, defaultVisibility, parentComment) {
         const comment = parentComment || utils.getCommentFromSourceCode(method.node, parseContext.sourceCode, { defaultVisibility });
 
-        this.parseKeywords(comment.keywords, method);
+        parseAndMergeKeywords(comment.keywords, method);
 
         const item = Object.assign({}, comment, {
             name: method.name,
@@ -201,7 +186,7 @@ class Parser extends EventEmitter {
             }];
         }
 
-        this.updateType(item);
+        updateType(item);
 
         this.emit('computed', item);
     }
@@ -318,7 +303,7 @@ class Parser extends EventEmitter {
             }
 
             if (node.type === 'VariableDeclaration' && parseContext.scopeType !== SCOPE_MARKUP) {
-                const variables = this.parseVariableDeclaration(node);
+                const variables = parseVariableDeclaration(node);
 
                 variables.forEach(variable => {
                     if (level === 0) {
@@ -356,7 +341,7 @@ class Parser extends EventEmitter {
             }
 
             if (node.type === 'FunctionDeclaration') {
-                this.emitMethodItem(this.parseFunctionDeclaration(node), parseContext, 'private');
+                this.emitMethodItem(parseFunctionDeclaration(node), parseContext, 'private');
 
                 if (node.body) {
                     this.parseBodyRecursively(node.body, parseContext, level + 1);
@@ -373,7 +358,7 @@ class Parser extends EventEmitter {
                     const exportNodeComment = utils.getCommentFromSourceCode(node, parseContext.sourceCode, { defaultVisibility: 'public', useLeading: true, useTrailing: false });
 
                     if (declaration.type === 'VariableDeclaration') {
-                        const variables = this.parseVariableDeclaration(declaration);
+                        const variables = parseVariableDeclaration(declaration);
 
                         variables.forEach(variable => {
                             this.emitDataItem(variable, parseContext, 'public', exportNodeComment);
@@ -403,7 +388,7 @@ class Parser extends EventEmitter {
                     }
 
                     if (declaration.type === 'FunctionDeclaration') {
-                        const func = this.parseFunctionDeclaration(declaration);
+                        const func = parseFunctionDeclaration(declaration);
 
                         this.emitMethodItem(func, parseContext, 'public', exportNodeComment);
 
@@ -581,7 +566,8 @@ class Parser extends EventEmitter {
         const regex = /^{?\s*function\s+\(/i;
 
         expression = expression.replace(regex, function (m) {
-            // When quotes in attributes used curcly braces are provided here, so we should handle it separatly
+            // When quotes in attributes used curly braces are provided here,
+            // so we should handle it separately
             if (m.startsWith('{')) {
                 return '{function a(';
             }
@@ -644,92 +630,6 @@ class Parser extends EventEmitter {
         };
     }
 
-    parseVariableDeclaration(node) {
-        if (node.type !== 'VariableDeclaration') {
-            throw new Error('Node should have a VariableDeclarationType, but is ' + node.type);
-        }
-
-        const result = [];
-
-        node.declarations.forEach(declarator => {
-            const idNode = declarator.id;
-
-            if (idNode.type === 'Identifier') {
-                result.push({
-                    name: idNode.name,
-                    kind: node.kind,
-                    node: node,
-                    declarator: declarator,
-                    location: {
-                        start: idNode.start,
-                        end: idNode.end
-                    }
-                });
-            } else if (idNode.type === 'ObjectPattern') {
-                idNode.properties.forEach(propertyNode => {
-                    const propertyIdNode = propertyNode.key;
-
-                    if (propertyIdNode.type === 'Identifier') {
-                        result.push({
-                            name: propertyIdNode.name,
-                            kind: node.kind,
-                            node: node,
-                            declarator: declarator,
-                            locations: {
-                                start: propertyIdNode.start,
-                                end: propertyIdNode.end
-                            }
-                        });
-                    }
-                });
-            }
-        });
-
-        return result;
-    }
-
-    parseFunctionDeclaration(node) {
-        if (node.type !== 'FunctionDeclaration') {
-            throw new Error('Node should have a FunctionDeclarationType, but is ' + node.type);
-        }
-
-        const params = [];
-
-        node.params.forEach((param) => {
-            if (param.type === 'Identifier') {
-                params.push({
-                    name: param.name,
-                });
-            }
-        });
-
-        const output = {
-            node: node,
-            name: node.id.name,
-            location: {
-                start: node.id.start,
-                end: node.id.end
-            },
-            params: params,
-        };
-
-        return output;
-    }
-
-    parseObjectProperty(node) {
-        if (node.type !== 'Property') {
-            throw new Error('Node should have a Property, but is ' + node.type);
-        }
-
-        if (node.key && node.key.type !== 'Identifier') {
-            throw new Error('Wrong property declaration');
-        }
-
-        return {
-            name: node.key.name
-        };
-    }
-
     parseTemplate() {
         let rootElementIndex = 0;
         let lastComment = null;
@@ -758,7 +658,7 @@ class Parser extends EventEmitter {
 
                 if (this.features.includes('events')) {
                     if (lastTagName !== 'slot') {
-                        // Expose events that propogated from child events
+                        // Expose events that propagated from child events
                         // Handle event syntax like ```<button on:click>Some link</button>```
                         if (name.length > 3 && name.indexOf('on:') === 0 && !value) {
                             const nameWithModificators = name.substr(3).split('|');
@@ -785,7 +685,7 @@ class Parser extends EventEmitter {
                             if (!hasOwnProperty(this.eventsEmitted, baseEvent.name)) {
                                 this.eventsEmitted[baseEvent.name] = baseEvent;
 
-                                this.parseKeywords(comment.keywords, baseEvent);
+                                parseAndMergeKeywords(comment.keywords, baseEvent);
 
                                 this.emit('event', baseEvent);
                             }
@@ -915,49 +815,6 @@ class Parser extends EventEmitter {
 
         parser.write(this.structure.template);
         parser.end();
-    }
-
-    /**
-     * Mutates event.
-     * @param {any[]} keywords
-     * @param {{ params?: any[] }} event
-     */
-    parseKeywords(keywords = [], event) {
-        if (!event.params) {
-            event.params = [];
-        }
-
-        keywords.forEach(({ name, description }) => {
-            if (name in PARAM_ALIASES) {
-                const parsedParam = jsdoc.parseParamKeyword(description);
-                const pIndex = event.params.findIndex(
-                    p => p.name === parsedParam.name
-                );
-
-                /*
-                 * Replace the param if there is already one present with
-                 * the same name. This will happen with parsed
-                 * FunctionDeclaration because params will already be
-                 * present from parsing the AST node.
-                 */
-                if (pIndex >= 0) {
-                    event.params[pIndex] = parsedParam;
-                } else {
-                    /*
-                     * This means @param does not match an actual param
-                     * in the FunctionDeclaration.
-                     * TODO: Implement option to choose behaviour (keep, ignore, warn, throw)
-                     */
-                    event.params.push(parsedParam);
-                }
-            } else if (name in RETURN_ALIASES) {
-                event.return = jsdoc.parseReturnKeyword(description);
-            }
-        });
-
-        if (event.params.length === 0) {
-            delete event.params;
-        }
     }
 }
 

--- a/lib/v3/script.js
+++ b/lib/v3/script.js
@@ -1,0 +1,434 @@
+const espree = require('espree');
+const eslint = require('eslint');
+const EventEmitter = require('events');
+
+const { getAstDefaultOptions } = require('../options');
+const {
+    hasOwnProperty,
+    getCommentFromSourceCode,
+    buildPropertyAccessorChainFromAst,
+    getValueForPropertyAccessorChain,
+} = require('../utils');
+
+const {
+    parseFunctionDeclaration,
+    parseVariableDeclaration,
+} = require('./v3-utils');
+
+const RE_STATIC_SCOPE = /\sscope=('module'|"module")/gi;
+
+const SCOPE_DEFAULT = 'default';
+const SCOPE_STATIC = 'static';
+const SCOPE_MARKUP = 'markup';
+
+class ScriptParser extends EventEmitter {
+    /**
+     * @typedef {import("../helpers").HtmlBlock} HtmlBlock
+     * @param {HtmlBlock[]} scripts
+     */
+    constructor(scripts) {
+        super();
+
+        this.scripts = scripts;
+
+        // Internal properties
+        this.identifiers = Object.create(null); // Empty Map
+        this.imports = Object.create(null); // Empty Map
+        this.dispatcherConstructorNames = [];
+        this.dispatcherNames = [];
+    }
+
+    parse() {
+        this.scripts.forEach(script => {
+            this.parseScript(script);
+        });
+    }
+
+    /**
+     * @param {HtmlBlock} script
+     */
+    parseScript(script) {
+        const ast = espree.parse(
+            script.content,
+            getAstDefaultOptions()
+        );
+        const sourceCode = new eslint.SourceCode({
+            text: script.content,
+            ast: ast
+        });
+
+        const isStaticScope = RE_STATIC_SCOPE.test(script.attributes);
+        const scriptParseContext = {
+            scopeType: isStaticScope
+                ? SCOPE_STATIC
+                : SCOPE_DEFAULT,
+            offset: script.offset,
+            sourceCode: sourceCode
+        };
+
+        this.parseBodyRecursively(ast, scriptParseContext, 0);
+    }
+
+    /**
+     * Call this to parse javascript expressions found in the template. The
+     * content of the parsed scripts, such as dispatchers and identifiers, are
+     * available so they will be recognized when used in template javascript
+     * expressions.
+     *
+     * @param {string} expression javascript expression found in the template
+     */
+    parseJavascriptExpression(expression, offset = 0) {
+        const expressionWrapper = {
+            content: expression,
+            offset: offset,
+        };
+
+        this.parseScript(expressionWrapper);
+    }
+
+    parseEventDeclaration(node) {
+        if (node.type !== 'CallExpression') {
+            throw new Error('Node should have a CallExpressionType, but is ' + node.type);
+        }
+
+        const args = node.arguments;
+
+        if (!args || !args.length) {
+            return null;
+        }
+
+        const nameNode = args[0];
+
+        let name;
+
+        try {
+            const chain = buildPropertyAccessorChainFromAst(nameNode);
+
+            // This function can throw if chain is not valid
+            name = getValueForPropertyAccessorChain(this.identifiers, chain);
+        } catch (error) {
+            name = nameNode.type === 'Literal'
+                ? nameNode.value
+                : undefined;
+        }
+
+        return {
+            name: name,
+            node: node,
+            location: {
+                start: nameNode.start,
+                end: nameNode.end
+            }
+        };
+    }
+
+    parseBodyRecursively(rootNode, parseContext, level) {
+        const nodes = rootNode.body
+            ? rootNode.body
+            : (rootNode.length > 0 ? rootNode : [rootNode]);
+
+        nodes.forEach((node, index) => {
+            if (index === 0 && level === 0) {
+                const firstComment = getCommentFromSourceCode(node, parseContext.sourceCode, { useTrailing: false, useFirst: true });
+
+                this.emit('global-comment', firstComment);
+            }
+
+            if (node.type === 'BlockStatement') {
+                this.parseBodyRecursively(node.body, parseContext, level);
+
+                return;
+            }
+
+            if (node.type === 'ExpressionStatement') {
+                const expressionNode = node.expression;
+
+                if (expressionNode.type === 'CallExpression') {
+                    const callee = expressionNode.callee;
+
+                    if (expressionNode.arguments) {
+                        this.parseBodyRecursively(expressionNode.arguments, parseContext, level + 1);
+                    }
+
+                    if (callee.type === 'Identifier' && this.dispatcherNames.indexOf(callee.name) >= 0) {
+                        const eventItem = this.parseEventDeclaration(expressionNode);
+
+                        this.emit('event', eventItem, parseContext);
+
+                        return;
+                    }
+                }
+
+                if (expressionNode.type === 'ArrowFunctionExpression') {
+                    if (expressionNode.body) {
+                        this.parseBodyRecursively(expressionNode.body, parseContext, level + 1);
+
+                        return;
+                    }
+                }
+            }
+
+            if (node.type === 'CallExpression') {
+                const callee = node.callee;
+
+                if (node.arguments) {
+                    this.parseBodyRecursively(node.arguments, parseContext, level + 1);
+                }
+
+                if (callee.type === 'Identifier' && this.dispatcherNames.includes(callee.name)) {
+                    const eventItem = this.parseEventDeclaration(node);
+
+                    this.emit('event', eventItem, parseContext);
+
+                    return;
+                }
+            }
+
+            if (node.type === 'VariableDeclaration' && parseContext.scopeType !== SCOPE_MARKUP) {
+                const variables = parseVariableDeclaration(node);
+
+                variables.forEach(variable => {
+                    if (level === 0) {
+                        this.emit('data', variable, parseContext, 'private');
+                    }
+
+                    if (variable.declarator.init) {
+                        const idNode = variable.declarator.id;
+                        const initNode = variable.declarator.init;
+
+                        // Store top level variables in 'identifiers'
+                        if (level === 0 && idNode.type === 'Identifier') {
+                            this.identifiers[idNode.name] = variable.declarator.init;
+                        }
+
+                        if (initNode.type === 'CallExpression') {
+                            const callee = initNode.callee;
+
+                            if (initNode.arguments) {
+                                this.parseBodyRecursively(initNode.arguments, parseContext, level + 1);
+                            }
+
+                            if (callee.type === 'Identifier' && this.dispatcherConstructorNames.includes(callee.name)) {
+                                this.dispatcherNames.push(variable.name);
+                            }
+                        } else if (initNode.type === 'ArrowFunctionExpression') {
+                            if (initNode.body) {
+                                this.parseBodyRecursively(initNode.body, parseContext, level + 1);
+                            }
+                        }
+                    }
+                });
+
+                return;
+            }
+
+            if (node.type === 'FunctionDeclaration') {
+                const func = parseFunctionDeclaration(node);
+
+                this.emit('method', func, parseContext, 'private');
+
+                if (node.body) {
+                    this.parseBodyRecursively(node.body, parseContext, level + 1);
+                }
+
+                return;
+            }
+
+            if (node.type === 'ExportNamedDeclaration' && level === 0 && parseContext.scopeType !== SCOPE_MARKUP) {
+                const declaration = node.declaration;
+                const specifiers = node.specifiers;
+
+                if (declaration) {
+                    const exportNodeComment = getCommentFromSourceCode(node, parseContext.sourceCode, { defaultVisibility: 'public', useLeading: true, useTrailing: false });
+
+                    if (declaration.type === 'VariableDeclaration') {
+                        const variables = parseVariableDeclaration(declaration);
+
+                        variables.forEach(variable => {
+                            this.emit('data', variable, parseContext, 'public', exportNodeComment);
+
+                            if (variable.declarator.init) {
+                                const initNode = variable.declarator.init;
+
+                                if (initNode.type === 'CallExpression') {
+                                    const callee = initNode.callee;
+
+                                    if (initNode.arguments) {
+                                        this.parseBodyRecursively(initNode.arguments, parseContext, level + 1);
+                                    }
+
+                                    if (callee.type === 'Identifier' && this.dispatcherConstructorNames.includes(callee.name)) {
+                                        this.dispatcherNames.push(variable.name);
+                                    }
+                                } else if (initNode.type === 'ArrowFunctionExpression') {
+                                    if (initNode.body) {
+                                        this.parseBodyRecursively(initNode.body, parseContext, level + 1);
+                                    }
+                                }
+                            }
+                        });
+
+                        return;
+                    }
+
+                    if (declaration.type === 'FunctionDeclaration') {
+                        const func = parseFunctionDeclaration(declaration);
+
+                        this.emit('method', func, parseContext, 'public', exportNodeComment);
+
+                        if (declaration.body) {
+                            this.parseBodyRecursively(declaration.body, parseContext, level + 1);
+                        }
+
+                        return;
+                    }
+                }
+
+                if (specifiers) {
+                    specifiers.forEach(specifier => {
+                        if (specifier.type === 'ExportSpecifier') {
+                            const exportedOrLocalName = specifier.exported
+                                ? specifier.exported.name
+                                : specifier.local.name;
+
+                            const dataItem = {
+                                node: specifier,
+                                name: exportedOrLocalName,
+                                localName: specifier.local.name,
+                                kind: 'const',
+                                location: {
+                                    start: specifier.exported ? specifier.exported.start : specifier.local.start,
+                                    end: specifier.exported ? specifier.exported.end : specifier.local.end
+                                }
+                            };
+
+                            this.emit('data', dataItem, parseContext, 'public');
+                        }
+                    });
+                }
+            }
+
+            if (node.type === 'LabeledStatement' && level === 0 && parseContext.scopeType !== SCOPE_MARKUP) {
+                const idNode = node.label;
+
+                if (idNode && idNode.type === 'Identifier' && idNode.name === '$') {
+                    if (node.body && node.body.type === 'ExpressionStatement') {
+                        const expression = node.body.expression;
+
+                        if (expression && expression.type === 'AssignmentExpression') {
+                            const leftNode = expression.left;
+
+                            if (leftNode.type === 'Identifier') {
+                                const computedItem = {
+                                    name: leftNode.name,
+                                    location: {
+                                        start: leftNode.start,
+                                        end: leftNode.end
+                                    },
+                                    node: node
+                                };
+
+                                this.emit('computed', computedItem, parseContext, 'private');
+
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (node.type === 'ImportDeclaration' && level === 0 && parseContext.scopeType !== SCOPE_MARKUP) {
+                const specifier = node.specifiers[0];
+                const source = node.source;
+
+                if (source && source.type === 'Literal') {
+                    const sourceFileName = source.value;
+
+                    if (specifier && specifier.type === 'ImportDefaultSpecifier') {
+                        const importEntry = {
+                            identifier: specifier.local.name,
+                            sourceFilename: sourceFileName
+                        };
+
+                        if (!hasOwnProperty(this.imports, importEntry.identifier)) {
+                            this.imports[importEntry.identifier] = importEntry;
+
+                            if (importEntry.identifier) {
+                                if (importEntry.identifier[0] === importEntry.identifier[0].toUpperCase()) {
+                                    const component = {
+                                        node: node,
+                                        name: importEntry.identifier,
+                                        path: importEntry.sourceFilename,
+                                        location: {
+                                            start: specifier.local.start,
+                                            end: specifier.local.end
+                                        }
+                                    };
+
+                                    this.emit('imported-component', component, parseContext);
+
+                                    return;
+                                } else {
+                                    const imported = specifier.imported
+                                        ? specifier.imported.name
+                                        : undefined;
+
+                                    const dataItem = {
+                                        node,
+                                        name: importEntry.identifier,
+                                        originalName: imported || importEntry.identifier,
+                                        importPath: importEntry.sourceFilename,
+                                        kind: 'const',
+                                        location: {
+                                            start: specifier.local.start,
+                                            end: specifier.local.end
+                                        }
+                                    };
+
+                                    this.emit('data', dataItem, parseContext, 'private');
+                                }
+                            }
+                        }
+                    } else if (node.specifiers.length > 0) {
+                        node.specifiers.forEach((specifier) => {
+                            if (specifier.type === 'ImportSpecifier') {
+                                const dataItem = {
+                                    node: specifier,
+                                    name: specifier.local.name,
+                                    originalName: specifier.imported
+                                        ? specifier.imported.name
+                                        : specifier.local.name,
+                                    importPath: sourceFileName,
+                                    kind: 'const',
+                                    location: {
+                                        start: specifier.local.start,
+                                        end: specifier.local.end
+                                    }
+                                };
+
+                                this.emit('data', dataItem, parseContext, 'private');
+                            }
+                        });
+                    }
+
+                    // Import svelte API functions
+                    if (sourceFileName === 'svelte') {
+                        // Dispatcher constructors
+                        node.specifiers
+                            .filter(specifier => specifier.imported.name === 'createEventDispatcher')
+                            .forEach(specifier => {
+                                this.dispatcherConstructorNames.push(specifier.local.name);
+                            });
+                    }
+                }
+            }
+
+            if (node.body) {
+                this.parseBodyRecursively(node.body, parseContext, level + 1);
+            }
+        });
+    }
+}
+
+module.exports = ScriptParser;
+module.exports.SCOPE_STATIC = SCOPE_STATIC;

--- a/lib/v3/script.js
+++ b/lib/v3/script.js
@@ -8,6 +8,7 @@ const {
     getCommentFromSourceCode,
     buildPropertyAccessorChainFromAst,
     getValueForPropertyAccessorChain,
+    inferTypeFromVariableDeclaration,
 } = require('../utils');
 
 const {
@@ -15,7 +16,11 @@ const {
     getInnermostBody,
     parseFunctionDeclaration,
     parseVariableDeclaration,
+    parseAndMergeKeywords,
+    updateType
 } = require('./v3-utils');
+
+const jsdoc = require('./../jsdoc');
 
 const { ScriptEvent } = require('./events');
 
@@ -32,15 +37,138 @@ const SCOPE_DEFAULT = 'default';
 const SCOPE_STATIC = 'static';
 const SCOPE_MARKUP = 'markup';
 
+/**
+ * @typedef ScriptParserOptions
+ * @property {Svelte3FeatureKeys[]} features
+ * @property {boolean} includeSourceLocations
+ */
+
 class ScriptParser extends EventEmitter {
-    constructor() {
+    /**
+     * @param {ScriptParserOptions} options
+     */
+    constructor(options) {
         super();
+
+        this.includeSourceLocations = options.includeSourceLocations;
+        this.features = options.features;
 
         // Internal properties
         this.identifiers = Object.create(null); // Empty Map
         this.imports = Object.create(null); // Empty Map
         this.dispatcherConstructorNames = [];
         this.dispatcherNames = [];
+    }
+
+    /**
+     * @sideEffect mutates `item.locations`.
+     *
+     * Attaches the node's location to the item if requested by the user.
+     *
+     * @param {import('../../typings').ISvelteItem} item the item to attach locations to
+     * @param {{ location?: { start: number, end: number } }} node the parsed node containing a location
+     * @param {{ offset: number }} context parse context containing an offset for locations
+     */
+    attachLocationsIfRequired(item, node, context) {
+        if (this.includeSourceLocations && node.location) {
+            item.locations = [{
+                start: node.location.start + context.offset,
+                end: node.location.end + context.offset,
+            }];
+        }
+    }
+
+    emitDataItem(variable, parseContext, defaultVisibility, parentComment) {
+        const comment = parentComment || getCommentFromSourceCode(variable.node, parseContext.sourceCode, { defaultVisibility });
+
+        /** @type {import('../../typings').SvelteDataItem} */
+        const item = {
+            ...comment,
+            name: variable.name,
+            kind: variable.kind,
+            static: parseContext.scopeType === SCOPE_STATIC,
+            readonly: variable.kind === 'const',
+            type: inferTypeFromVariableDeclaration(variable),
+            importPath: variable.importPath,
+            originalName: variable.originalName,
+            localName: variable.localName,
+        };
+
+        if (variable.declarator && variable.declarator.init) {
+            item.defaultValue = variable.declarator.init.value;
+        }
+
+        this.attachLocationsIfRequired(item, variable, parseContext);
+
+        updateType(item);
+
+        this.emit(ScriptEvent.DATA, item);
+    }
+
+    emitMethodItem(method, parseContext, defaultVisibility, parentComment) {
+        const comment = parentComment || getCommentFromSourceCode(method.node, parseContext.sourceCode, { defaultVisibility });
+
+        parseAndMergeKeywords(comment.keywords, method);
+
+        /** @type {import('../../typings').SvelteMethodItem} */
+        const item = {
+            ...comment,
+            name: method.name,
+            params: method.params,
+            return: method.return,
+            static: parseContext.scopeType === SCOPE_STATIC
+        };
+
+        this.attachLocationsIfRequired(item, method, parseContext);
+
+        this.emit(ScriptEvent.METHOD, item);
+    }
+
+    emitComputedItem(computed, parseContext, defaultVisibility) {
+        const comment = getCommentFromSourceCode(computed.node, parseContext.sourceCode, { defaultVisibility });
+
+        /** @type {import('../../typings').SvelteComputedItem} */
+        const item = {
+            ...comment,
+            name: computed.name,
+            static: parseContext.scopeType === SCOPE_STATIC,
+            type: jsdoc.DEFAULT_TYPE
+        };
+
+        this.attachLocationsIfRequired(item, computed, parseContext);
+
+        updateType(item);
+
+        this.emit(ScriptEvent.COMPUTED, item);
+    }
+
+    emitEventItem(event, parseContext) {
+        const comment = getCommentFromSourceCode(event.node, parseContext.sourceCode, { defaultVisibility: 'public' });
+
+        /** @type {import('../../typings').SvelteEventItem} */
+        const item = {
+            ...comment,
+            name: event.name
+        };
+
+        this.attachLocationsIfRequired(item, event, parseContext);
+
+        this.emit(ScriptEvent.EVENT, item);
+    }
+
+    emitImportedComponentItem(component, parseContext) {
+        const comment = getCommentFromSourceCode(component.node, parseContext.sourceCode, { defaultVisibility: 'private' });
+
+        /** @type {import('../../typings').SvelteComponentItem} */
+        const item = {
+            ...comment,
+            name: component.name,
+            importPath: component.path,
+        };
+
+        this.attachLocationsIfRequired(item, component, parseContext);
+
+        this.emit(ScriptEvent.IMPORTED_COMPONENT, item);
     }
 
     /**
@@ -109,7 +237,7 @@ class ScriptParser extends EventEmitter {
 
         variables.forEach(variable => {
             if (level === 0) {
-                this.emit(ScriptEvent.DATA, variable, context, visibility, comment);
+                this.emitDataItem(variable, context, visibility, comment);
             }
 
             if (!variable.declarator.init) {
@@ -226,7 +354,7 @@ class ScriptParser extends EventEmitter {
                 if (callee.type === 'Identifier' && this.dispatcherNames.includes(callee.name)) {
                     const eventItem = this.parseEventDeclaration(node);
 
-                    this.emit(ScriptEvent.EVENT, eventItem, parseContext);
+                    this.emitEventItem(eventItem, parseContext);
                 }
 
                 return;
@@ -241,7 +369,7 @@ class ScriptParser extends EventEmitter {
             if (node.type === 'FunctionDeclaration') {
                 const func = parseFunctionDeclaration(node);
 
-                this.emit(ScriptEvent.METHOD, func, parseContext, 'private');
+                this.emitMethodItem(func, parseContext, 'private');
                 this.parseBodyRecursively(node, parseContext, level + 1);
 
                 return;
@@ -271,7 +399,7 @@ class ScriptParser extends EventEmitter {
                     if (declaration.type === 'FunctionDeclaration') {
                         const func = parseFunctionDeclaration(declaration);
 
-                        this.emit(ScriptEvent.METHOD, func, parseContext, 'public', exportNodeComment);
+                        this.emitMethodItem(func, parseContext, 'public', exportNodeComment);
                         this.parseBodyRecursively(declaration, parseContext, level + 1);
                     }
                 }
@@ -291,7 +419,7 @@ class ScriptParser extends EventEmitter {
                                 }
                             };
 
-                            this.emit(ScriptEvent.DATA, dataItem, parseContext, 'public');
+                            this.emitDataItem(dataItem, parseContext, 'public');
                         }
                     });
                 }
@@ -323,7 +451,7 @@ class ScriptParser extends EventEmitter {
                                     node: node
                                 };
 
-                                this.emit(ScriptEvent.COMPUTED, computedItem, parseContext, 'private');
+                                this.emitComputedItem(computedItem, parseContext, 'private');
                             }
                         }
                     }
@@ -360,7 +488,7 @@ class ScriptParser extends EventEmitter {
                                         }
                                     };
 
-                                    this.emit(ScriptEvent.IMPORTED_COMPONENT, component, parseContext);
+                                    this.emitImportedComponentItem(component, parseContext);
 
                                     return;
                                 } else {
@@ -380,7 +508,7 @@ class ScriptParser extends EventEmitter {
                                         }
                                     };
 
-                                    this.emit(ScriptEvent.DATA, dataItem, parseContext, 'private');
+                                    this.emitDataItem(dataItem, parseContext, 'private');
                                 }
                             }
                         }
@@ -401,7 +529,7 @@ class ScriptParser extends EventEmitter {
                                     }
                                 };
 
-                                this.emit(ScriptEvent.DATA, dataItem, parseContext, 'private');
+                                this.emitDataItem(dataItem, parseContext, 'private');
                             }
                         });
                     }

--- a/lib/v3/script.js
+++ b/lib/v3/script.js
@@ -17,6 +17,8 @@ const {
 
 const RE_STATIC_SCOPE = /\sscope=('module'|"module")/gi;
 
+/** @typedef {'default' | 'static' | 'markup'} ScopeType */
+
 const SCOPE_DEFAULT = 'default';
 const SCOPE_STATIC = 'static';
 const SCOPE_MARKUP = 'markup';
@@ -45,9 +47,10 @@ class ScriptParser extends EventEmitter {
     }
 
     /**
-     * @param {HtmlBlock} script
+     * @param {{ content: string; offset: number; attributes?: string }} script
+     * @param {'default' | 'static' | 'markup'} scope if passed, overrides the scopeType used during parsing
      */
-    parseScript(script) {
+    parseScript(script, scope) {
         const ast = espree.parse(
             script.content,
             getAstDefaultOptions()
@@ -59,9 +62,7 @@ class ScriptParser extends EventEmitter {
 
         const isStaticScope = RE_STATIC_SCOPE.test(script.attributes);
         const scriptParseContext = {
-            scopeType: isStaticScope
-                ? SCOPE_STATIC
-                : SCOPE_DEFAULT,
+            scopeType: scope || (isStaticScope ? SCOPE_STATIC : SCOPE_DEFAULT),
             offset: script.offset,
             sourceCode: sourceCode
         };
@@ -83,7 +84,7 @@ class ScriptParser extends EventEmitter {
             offset: offset,
         };
 
-        this.parseScript(expressionWrapper);
+        this.parseScript(expressionWrapper, SCOPE_MARKUP);
     }
 
     parseEventDeclaration(node) {

--- a/lib/v3/script.js
+++ b/lib/v3/script.js
@@ -306,8 +306,8 @@ class ScriptParser extends EventEmitter {
     /**
      *
      * @param {{ body: AstNode | AstNode[] } | AstNode[]} rootNode
-     * @param {*} parseContext
-     * @param {*} level
+     * @param {{ scopeType: ScopeType; sourceCode: eslint.SourceCode; offset: number }} parseContext
+     * @param {number} level
      */
     parseBodyRecursively(rootNode, parseContext, level) {
         if (!rootNode) {

--- a/lib/v3/script.js
+++ b/lib/v3/script.js
@@ -11,9 +11,15 @@ const {
 } = require('../utils');
 
 const {
+    assertNodeType,
+    getInnermostBody,
     parseFunctionDeclaration,
     parseVariableDeclaration,
 } = require('./v3-utils');
+
+/**
+ * @typedef {import('./v3-utils').AstNode} AstNode
+ */
 
 const RE_STATIC_SCOPE = /\sscope=('module'|"module")/gi;
 
@@ -48,7 +54,7 @@ class ScriptParser extends EventEmitter {
 
     /**
      * @param {{ content: string; offset: number; attributes?: string }} script
-     * @param {'default' | 'static' | 'markup'} scope if passed, overrides the scopeType used during parsing
+     * @param {ScopeType} scope if passed, overrides the scopeType used during parsing
      */
     parseScript(script, scope) {
         const ast = espree.parse(
@@ -87,10 +93,49 @@ class ScriptParser extends EventEmitter {
         this.parseScript(expressionWrapper, SCOPE_MARKUP);
     }
 
-    parseEventDeclaration(node) {
-        if (node.type !== 'CallExpression') {
-            throw new Error('Node should have a CallExpressionType, but is ' + node.type);
+    parseVariableDeclarations(declaration, context, level, visibility, comment = undefined) {
+        if (context.scopeType === SCOPE_MARKUP) {
+            return;
         }
+
+        const variables = parseVariableDeclaration(declaration);
+
+        variables.forEach(variable => {
+            if (level === 0) {
+                this.emit('data', variable, context, visibility, comment);
+            }
+
+            if (!variable.declarator.init) {
+                return;
+            }
+
+            const id = variable.declarator.id;
+            const init = variable.declarator.init;
+
+            // Store top level variables in 'identifiers'
+            if (level === 0 && id.type === 'Identifier') {
+                this.identifiers[id.name] = init;
+            }
+
+            if (init.type === 'CallExpression') {
+                const callee = init.callee;
+
+                if (init.arguments) {
+                    this.parseBodyRecursively(init.arguments, context, level + 1);
+                }
+
+                if (callee.type === 'Identifier' && this.dispatcherConstructorNames.includes(callee.name)) {
+                    this.dispatcherNames.push(variable.name);
+                }
+            } else if (init.type === 'ArrowFunctionExpression') {
+                this.parseBodyRecursively(init, context, level + 1);
+            }
+        }
+        );
+    }
+
+    parseEventDeclaration(node) {
+        assertNodeType(node, 'CallExpression');
 
         const args = node.arguments;
 
@@ -123,50 +168,45 @@ class ScriptParser extends EventEmitter {
         };
     }
 
+    /**
+     *
+     * @param {{ body: AstNode | AstNode[] } | AstNode[]} rootNode
+     * @param {*} parseContext
+     * @param {*} level
+     */
     parseBodyRecursively(rootNode, parseContext, level) {
-        const nodes = rootNode.body
-            ? rootNode.body
-            : (rootNode.length > 0 ? rootNode : [rootNode]);
+        if (!rootNode) {
+            throw TypeError('parseBodyRecursively was called without a node');
+        }
 
-        nodes.forEach((node, index) => {
-            if (index === 0 && level === 0) {
-                const firstComment = getCommentFromSourceCode(node, parseContext.sourceCode, { useTrailing: false, useFirst: true });
+        const body = getInnermostBody(rootNode);
+        const nodes = Array.isArray(body) ? body : [body];
 
-                this.emit('global-comment', firstComment);
-            }
+        if (nodes[0] && level === 0) {
+            this.emit('global-comment', getCommentFromSourceCode(
+                nodes[0],
+                parseContext.sourceCode,
+                { useTrailing: false, useFirst: true }
+            ));
+        }
 
+        nodes.forEach((node) => {
             if (node.type === 'BlockStatement') {
-                this.parseBodyRecursively(node.body, parseContext, level);
+                this.parseBodyRecursively(node, parseContext, level);
 
                 return;
             }
 
             if (node.type === 'ExpressionStatement') {
-                const expressionNode = node.expression;
+                const expression = node.expression;
 
-                if (expressionNode.type === 'CallExpression') {
-                    const callee = expressionNode.callee;
-
-                    if (expressionNode.arguments) {
-                        this.parseBodyRecursively(expressionNode.arguments, parseContext, level + 1);
-                    }
-
-                    if (callee.type === 'Identifier' && this.dispatcherNames.indexOf(callee.name) >= 0) {
-                        const eventItem = this.parseEventDeclaration(expressionNode);
-
-                        this.emit('event', eventItem, parseContext);
-
-                        return;
-                    }
+                if (expression.type === 'CallExpression') {
+                    this.parseBodyRecursively(expression, parseContext, level);
+                } else if (expression.type === 'ArrowFunctionExpression') {
+                    this.parseBodyRecursively(expression, parseContext, level + 1);
                 }
 
-                if (expressionNode.type === 'ArrowFunctionExpression') {
-                    if (expressionNode.body) {
-                        this.parseBodyRecursively(expressionNode.body, parseContext, level + 1);
-
-                        return;
-                    }
-                }
+                return;
             }
 
             if (node.type === 'CallExpression') {
@@ -180,45 +220,13 @@ class ScriptParser extends EventEmitter {
                     const eventItem = this.parseEventDeclaration(node);
 
                     this.emit('event', eventItem, parseContext);
-
-                    return;
                 }
+
+                return;
             }
 
             if (node.type === 'VariableDeclaration' && parseContext.scopeType !== SCOPE_MARKUP) {
-                const variables = parseVariableDeclaration(node);
-
-                variables.forEach(variable => {
-                    if (level === 0) {
-                        this.emit('data', variable, parseContext, 'private');
-                    }
-
-                    if (variable.declarator.init) {
-                        const idNode = variable.declarator.id;
-                        const initNode = variable.declarator.init;
-
-                        // Store top level variables in 'identifiers'
-                        if (level === 0 && idNode.type === 'Identifier') {
-                            this.identifiers[idNode.name] = variable.declarator.init;
-                        }
-
-                        if (initNode.type === 'CallExpression') {
-                            const callee = initNode.callee;
-
-                            if (initNode.arguments) {
-                                this.parseBodyRecursively(initNode.arguments, parseContext, level + 1);
-                            }
-
-                            if (callee.type === 'Identifier' && this.dispatcherConstructorNames.includes(callee.name)) {
-                                this.dispatcherNames.push(variable.name);
-                            }
-                        } else if (initNode.type === 'ArrowFunctionExpression') {
-                            if (initNode.body) {
-                                this.parseBodyRecursively(initNode.body, parseContext, level + 1);
-                            }
-                        }
-                    }
-                });
+                this.parseVariableDeclarations(node, parseContext, level, 'private');
 
                 return;
             }
@@ -227,10 +235,7 @@ class ScriptParser extends EventEmitter {
                 const func = parseFunctionDeclaration(node);
 
                 this.emit('method', func, parseContext, 'private');
-
-                if (node.body) {
-                    this.parseBodyRecursively(node.body, parseContext, level + 1);
-                }
+                this.parseBodyRecursively(node, parseContext, level + 1);
 
                 return;
             }
@@ -240,66 +245,42 @@ class ScriptParser extends EventEmitter {
                 const specifiers = node.specifiers;
 
                 if (declaration) {
-                    const exportNodeComment = getCommentFromSourceCode(node, parseContext.sourceCode, { defaultVisibility: 'public', useLeading: true, useTrailing: false });
+                    const exportNodeComment = getCommentFromSourceCode(
+                        node,
+                        parseContext.sourceCode,
+                        { defaultVisibility: 'public', useLeading: true, useTrailing: false }
+                    );
 
                     if (declaration.type === 'VariableDeclaration') {
-                        const variables = parseVariableDeclaration(declaration);
-
-                        variables.forEach(variable => {
-                            this.emit('data', variable, parseContext, 'public', exportNodeComment);
-
-                            if (variable.declarator.init) {
-                                const initNode = variable.declarator.init;
-
-                                if (initNode.type === 'CallExpression') {
-                                    const callee = initNode.callee;
-
-                                    if (initNode.arguments) {
-                                        this.parseBodyRecursively(initNode.arguments, parseContext, level + 1);
-                                    }
-
-                                    if (callee.type === 'Identifier' && this.dispatcherConstructorNames.includes(callee.name)) {
-                                        this.dispatcherNames.push(variable.name);
-                                    }
-                                } else if (initNode.type === 'ArrowFunctionExpression') {
-                                    if (initNode.body) {
-                                        this.parseBodyRecursively(initNode.body, parseContext, level + 1);
-                                    }
-                                }
-                            }
-                        });
-
-                        return;
+                        this.parseVariableDeclarations(
+                            declaration,
+                            parseContext,
+                            level,
+                            'public',
+                            exportNodeComment
+                        );
                     }
 
                     if (declaration.type === 'FunctionDeclaration') {
                         const func = parseFunctionDeclaration(declaration);
 
                         this.emit('method', func, parseContext, 'public', exportNodeComment);
-
-                        if (declaration.body) {
-                            this.parseBodyRecursively(declaration.body, parseContext, level + 1);
-                        }
-
-                        return;
+                        this.parseBodyRecursively(declaration, parseContext, level + 1);
                     }
                 }
 
                 if (specifiers) {
                     specifiers.forEach(specifier => {
                         if (specifier.type === 'ExportSpecifier') {
-                            const exportedOrLocalName = specifier.exported
-                                ? specifier.exported.name
-                                : specifier.local.name;
-
+                            const subNode = specifier.exported ? 'exported' : 'local';
                             const dataItem = {
                                 node: specifier,
-                                name: exportedOrLocalName,
+                                name: specifier[subNode].name,
                                 localName: specifier.local.name,
                                 kind: 'const',
                                 location: {
-                                    start: specifier.exported ? specifier.exported.start : specifier.local.start,
-                                    end: specifier.exported ? specifier.exported.end : specifier.local.end
+                                    start: specifier[subNode].start,
+                                    end: specifier[subNode].end
                                 }
                             };
 
@@ -307,12 +288,18 @@ class ScriptParser extends EventEmitter {
                         }
                     });
                 }
+
+                return;
             }
 
+            /**
+             * Special case for reactive declarations (computed)
+             * In this case, the body is not parsed recursively.
+             */
             if (node.type === 'LabeledStatement' && level === 0 && parseContext.scopeType !== SCOPE_MARKUP) {
-                const idNode = node.label;
+                const label = node.label;
 
-                if (idNode && idNode.type === 'Identifier' && idNode.name === '$') {
+                if (label && label.type === 'Identifier' && label.name === '$') {
                     if (node.body && node.body.type === 'ExpressionStatement') {
                         const expression = node.body.expression;
 
@@ -330,12 +317,12 @@ class ScriptParser extends EventEmitter {
                                 };
 
                                 this.emit('computed', computedItem, parseContext, 'private');
-
-                                return;
                             }
                         }
                     }
                 }
+
+                return;
             }
 
             if (node.type === 'ImportDeclaration' && level === 0 && parseContext.scopeType !== SCOPE_MARKUP) {
@@ -422,8 +409,14 @@ class ScriptParser extends EventEmitter {
                             });
                     }
                 }
+
+                return;
             }
 
+            /**
+             * There must be a check for body presence because otherwise
+             * the parser gets stuck in an infinite loop on some nodes
+             */
             if (node.body) {
                 this.parseBodyRecursively(node.body, parseContext, level + 1);
             }

--- a/lib/v3/script.js
+++ b/lib/v3/script.js
@@ -17,10 +17,13 @@ const {
     parseVariableDeclaration,
 } = require('./v3-utils');
 
+const { ScriptEvent } = require('./events');
+
 /**
  * @typedef {import('./v3-utils').AstNode} AstNode
  */
 
+const RE_ANONYMOUS_FUNCTION = /^{?\s*function\s+\(/i;
 const RE_STATIC_SCOPE = /\sscope=('module'|"module")/gi;
 
 /** @typedef {'default' | 'static' | 'markup'} ScopeType */
@@ -30,14 +33,8 @@ const SCOPE_STATIC = 'static';
 const SCOPE_MARKUP = 'markup';
 
 class ScriptParser extends EventEmitter {
-    /**
-     * @typedef {import("../helpers").HtmlBlock} HtmlBlock
-     * @param {HtmlBlock[]} scripts
-     */
-    constructor(scripts) {
+    constructor() {
         super();
-
-        this.scripts = scripts;
 
         // Internal properties
         this.identifiers = Object.create(null); // Empty Map
@@ -46,8 +43,12 @@ class ScriptParser extends EventEmitter {
         this.dispatcherNames = [];
     }
 
-    parse() {
-        this.scripts.forEach(script => {
+    /**
+     * @typedef {import("../helpers").HtmlBlock} HtmlBlock
+     * @param {HtmlBlock[]} scripts
+     */
+    parse(scripts) {
+        scripts.forEach(script => {
             this.parseScript(script);
         });
     }
@@ -84,7 +85,13 @@ class ScriptParser extends EventEmitter {
      *
      * @param {string} expression javascript expression found in the template
      */
-    parseJavascriptExpression(expression, offset = 0) {
+    parseScriptExpression(expression, offset = 0) {
+        // Add name for anonymous functions to prevent parser error
+        expression = expression.replace(RE_ANONYMOUS_FUNCTION, function (m) {
+            // Preserve the curly brace if it appears in the quotes
+            return m.startsWith('{') ? '{function a(' : 'function a(';
+        });
+
         const expressionWrapper = {
             content: expression,
             offset: offset,
@@ -102,7 +109,7 @@ class ScriptParser extends EventEmitter {
 
         variables.forEach(variable => {
             if (level === 0) {
-                this.emit('data', variable, context, visibility, comment);
+                this.emit(ScriptEvent.DATA, variable, context, visibility, comment);
             }
 
             if (!variable.declarator.init) {
@@ -183,7 +190,7 @@ class ScriptParser extends EventEmitter {
         const nodes = Array.isArray(body) ? body : [body];
 
         if (nodes[0] && level === 0) {
-            this.emit('global-comment', getCommentFromSourceCode(
+            this.emit(ScriptEvent.GLOBAL_COMMENT, getCommentFromSourceCode(
                 nodes[0],
                 parseContext.sourceCode,
                 { useTrailing: false, useFirst: true }
@@ -219,7 +226,7 @@ class ScriptParser extends EventEmitter {
                 if (callee.type === 'Identifier' && this.dispatcherNames.includes(callee.name)) {
                     const eventItem = this.parseEventDeclaration(node);
 
-                    this.emit('event', eventItem, parseContext);
+                    this.emit(ScriptEvent.EVENT, eventItem, parseContext);
                 }
 
                 return;
@@ -234,7 +241,7 @@ class ScriptParser extends EventEmitter {
             if (node.type === 'FunctionDeclaration') {
                 const func = parseFunctionDeclaration(node);
 
-                this.emit('method', func, parseContext, 'private');
+                this.emit(ScriptEvent.METHOD, func, parseContext, 'private');
                 this.parseBodyRecursively(node, parseContext, level + 1);
 
                 return;
@@ -264,7 +271,7 @@ class ScriptParser extends EventEmitter {
                     if (declaration.type === 'FunctionDeclaration') {
                         const func = parseFunctionDeclaration(declaration);
 
-                        this.emit('method', func, parseContext, 'public', exportNodeComment);
+                        this.emit(ScriptEvent.METHOD, func, parseContext, 'public', exportNodeComment);
                         this.parseBodyRecursively(declaration, parseContext, level + 1);
                     }
                 }
@@ -284,7 +291,7 @@ class ScriptParser extends EventEmitter {
                                 }
                             };
 
-                            this.emit('data', dataItem, parseContext, 'public');
+                            this.emit(ScriptEvent.DATA, dataItem, parseContext, 'public');
                         }
                     });
                 }
@@ -316,7 +323,7 @@ class ScriptParser extends EventEmitter {
                                     node: node
                                 };
 
-                                this.emit('computed', computedItem, parseContext, 'private');
+                                this.emit(ScriptEvent.COMPUTED, computedItem, parseContext, 'private');
                             }
                         }
                     }
@@ -353,7 +360,7 @@ class ScriptParser extends EventEmitter {
                                         }
                                     };
 
-                                    this.emit('imported-component', component, parseContext);
+                                    this.emit(ScriptEvent.IMPORTED_COMPONENT, component, parseContext);
 
                                     return;
                                 } else {
@@ -373,7 +380,7 @@ class ScriptParser extends EventEmitter {
                                         }
                                     };
 
-                                    this.emit('data', dataItem, parseContext, 'private');
+                                    this.emit(ScriptEvent.DATA, dataItem, parseContext, 'private');
                                 }
                             }
                         }
@@ -394,7 +401,7 @@ class ScriptParser extends EventEmitter {
                                     }
                                 };
 
-                                this.emit('data', dataItem, parseContext, 'private');
+                                this.emit(ScriptEvent.DATA, dataItem, parseContext, 'private');
                             }
                         });
                     }

--- a/lib/v3/template.js
+++ b/lib/v3/template.js
@@ -6,13 +6,12 @@ const { parseComment, hasOwnProperty } = require('../utils');
 const { TemplateEvent } = require('./events');
 
 /**
- * @typedef {import('../../typings').Svelte3FeatureKeys} Svelte3FeatureKeys
+ * @typedef {import('../../typings').Svelte3Feature} Svelte3Feature
  *
  * @typedef TemplateParserOptions
- * @property {Svelte3FeatureKeys[]} features
+ * @property {Svelte3Feature[]} features
  * @property {boolean} includeSourceLocations
  */
-
 class TemplateParser extends EventEmitter {
     /**
      * @param {TemplateParserOptions} options

--- a/lib/v3/template.js
+++ b/lib/v3/template.js
@@ -3,7 +3,6 @@ const { Parser: HtmlParser } = require('htmlparser2-svelte');
 
 const { parseAndMergeKeywords } = require('./v3-utils');
 const { parseComment, hasOwnProperty } = require('../utils');
-const { getAstDefaultOptions } = require('../options');
 
 const TemplateEvent = Object.freeze({
     DATA: 'data',
@@ -24,11 +23,15 @@ class TemplateParser extends EventEmitter {
         super();
 
         this.structure = parser.structure;
-        this.astOptions = getAstDefaultOptions();
         this.features = parser.features;
         this.includeSourceLocations = parser.includeSourceLocations;
 
-        this.eventsEmitted = parser.eventsEmitted;
+        // Internal properties
+        /**
+         * Map of events already emitted. Check if an event exists in this map
+         * before emitting it again.
+         */
+        this.eventsEmitted = Object.create(null); // Empty Map
     }
 
     parse() {

--- a/lib/v3/template.js
+++ b/lib/v3/template.js
@@ -3,28 +3,25 @@ const { Parser: HtmlParser } = require('htmlparser2-svelte');
 
 const { parseAndMergeKeywords } = require('./v3-utils');
 const { parseComment, hasOwnProperty } = require('../utils');
+const { TemplateEvent } = require('./events');
 
-const TemplateEvent = Object.freeze({
-    DATA: 'data',
-    EVENT: 'event',
-    NAME: 'name',
-    REF: 'ref',
-    SLOT: 'slot',
-    EXPRESSION: 'expression',
-    GLOBAL_COMMENT: 'global-comment',
-});
+/**
+ * @typedef {import('../../typings').Svelte3FeatureKeys} Svelte3FeatureKeys
+ *
+ * @typedef TemplateParserOptions
+ * @property {Svelte3FeatureKeys[]} features
+ * @property {boolean} includeSourceLocations
+ */
 
 class TemplateParser extends EventEmitter {
     /**
-     * @typedef {import("./parser")} Svelte3Parser
-     * @param {Svelte3Parser} parser
+     * @param {TemplateParserOptions} options
      */
-    constructor(parser) {
+    constructor(options) {
         super();
 
-        this.structure = parser.structure;
-        this.features = parser.features;
-        this.includeSourceLocations = parser.includeSourceLocations;
+        this.features = options.features;
+        this.includeSourceLocations = options.includeSourceLocations;
 
         // Internal properties
         /**
@@ -34,15 +31,20 @@ class TemplateParser extends EventEmitter {
         this.eventsEmitted = Object.create(null); // Empty Map
     }
 
-    parse() {
+    /**
+     * Parse the template markup and produce events with parsed data.
+     * @param {string} template The template markup to parse
+     */
+    parse(template) {
         const options = {
             lowerCaseTags: false,
             lowerCaseAttributeNames: false,
             curlyBracesInAttributes: true
         };
+
         const parser = new HtmlParser(this.getTemplateHandler(), options);
 
-        parser.write(this.structure.template);
+        parser.write(template);
         parser.end();
     }
 

--- a/lib/v3/template.js
+++ b/lib/v3/template.js
@@ -1,0 +1,237 @@
+const EventEmitter = require('events');
+const { Parser: HtmlParser } = require('htmlparser2-svelte');
+
+const { parseAndMergeKeywords } = require('./v3-utils');
+const { parseComment, hasOwnProperty } = require('../utils');
+const { getAstDefaultOptions } = require('../options');
+
+const TemplateEvent = Object.freeze({
+    DATA: 'data',
+    EVENT: 'event',
+    NAME: 'name',
+    REF: 'ref',
+    SLOT: 'slot',
+    EXPRESSION: 'expression',
+    GLOBAL_COMMENT: 'global-comment',
+});
+
+class TemplateParser extends EventEmitter {
+    /**
+     * @typedef {import("./parser")} Svelte3Parser
+     * @param {Svelte3Parser} parser
+     */
+    constructor(parser) {
+        super();
+
+        this.structure = parser.structure;
+        this.astOptions = getAstDefaultOptions();
+        this.features = parser.features;
+        this.includeSourceLocations = parser.includeSourceLocations;
+
+        this.eventsEmitted = parser.eventsEmitted;
+    }
+
+    parse() {
+        const options = {
+            lowerCaseTags: false,
+            lowerCaseAttributeNames: false,
+            curlyBracesInAttributes: true
+        };
+        const parser = new HtmlParser(this.getTemplateHandler(), options);
+
+        parser.write(this.structure.template);
+        parser.end();
+    }
+
+    getTemplateHandler() {
+        let rootElementIndex = 0;
+        let lastComment = null;
+        let lastAttributeIndex = 0;
+        let lastAttributeLocations = {};
+        let lastTagName = null;
+        let parser = null;
+
+        return {
+            onparserinit: (parserInstance) => {
+                parser = parserInstance;
+            },
+            oncomment: (data) => {
+                lastComment = data.trim();
+            },
+            ontext: (text) => {
+                if (text.trim()) {
+                    lastComment = null;
+                }
+            },
+            onattribute: (name, value) => {
+                if (this.includeSourceLocations && parser.startIndex >= 0 && parser.endIndex >= parser.startIndex) {
+                    lastAttributeLocations[name] = {
+                        start: lastAttributeIndex,
+                        end: parser._tokenizer._index
+                    };
+
+                    lastAttributeIndex = parser._tokenizer._index;
+                }
+
+                if (this.features.includes('events')) {
+                    if (lastTagName !== 'slot') {
+                        // Expose events that propagated from child events
+                        // Handle event syntax like ```<button on:click>Some link</button>```
+                        if (name.length > 3 && name.indexOf('on:') === 0 && !value) {
+                            const nameWithModificators = name.substr(3).split('|');
+
+                            const baseEvent = {
+                                name: nameWithModificators[0],
+                                parent: lastTagName,
+                                modificators: nameWithModificators.slice(1),
+                                locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
+                                    ? [lastAttributeLocations[name]]
+                                    : null
+                            };
+
+                            if (lastComment) {
+                                lastComment = `/** ${lastComment} */`;
+                            }
+
+                            const comment = parseComment(lastComment || '');
+
+                            baseEvent.visibility = comment.visibility;
+                            baseEvent.description = comment.description || '';
+                            baseEvent.keywords = comment.keywords;
+
+                            if (!hasOwnProperty(this.eventsEmitted, baseEvent.name)) {
+                                this.eventsEmitted[baseEvent.name] = baseEvent;
+
+                                parseAndMergeKeywords(comment.keywords, baseEvent);
+
+                                this.emit(TemplateEvent.EVENT, baseEvent);
+                            }
+
+                            lastComment = null;
+                        }
+
+                        // Parse event handlers
+                        if (name.length > 3 && name.indexOf('on:') === 0 && value) {
+                            this.emit(TemplateEvent.EXPRESSION, value);
+                        }
+                    }
+                }
+            },
+            onopentagname: (tagName) => {
+                lastTagName = tagName;
+                lastAttributeIndex = parser._tokenizer._index;
+                lastAttributeLocations = {};
+            },
+            onopentag: (tagName, attrs) => {
+                const isNotStyleOrScript = !['style', 'script'].includes(tagName);
+                const isTopLevelElement = parser._stack.length === 1;
+
+                if (isTopLevelElement && isNotStyleOrScript) {
+                    if (lastComment && rootElementIndex === 0) {
+                        const parsedComment = parseComment(lastComment);
+
+                        this.emit(TemplateEvent.GLOBAL_COMMENT, parsedComment);
+                    }
+
+                    rootElementIndex += 1;
+                }
+
+                if (tagName === 'slot') {
+                    if (this.features.includes('slots')) {
+                        const exposedParameters = Object.keys(attrs)
+                            .filter(name => name.length > 0 && name !== 'name')
+                            .map(name => ({
+                                name: name,
+                                visibility: 'public'
+                            }));
+
+                        const slot = {
+                            name: attrs.name || 'default',
+                            description: lastComment,
+                            visibility: 'public',
+                            parameters: exposedParameters
+                        };
+
+                        if (this.includeSourceLocations && parser.startIndex >= 0 && parser.endIndex >= parser.startIndex) {
+                            slot.loc = {
+                                start: parser.startIndex,
+                                end: parser.endIndex
+                            };
+                        }
+
+                        this.emit(TemplateEvent.SLOT, slot);
+                    }
+                } else {
+                    if (tagName === 'svelte:options' && attrs.tag) {
+                        if (this.features.includes('name')) {
+                            this.emit(TemplateEvent.NAME, attrs.tag);
+                        }
+                    }
+
+                    if (this.features.includes('data')) {
+                        const bindProperties = Object.keys(attrs)
+                            .filter(name => name.length > 5 && name.indexOf('bind:') === 0)
+                            .filter(name => name !== 'bind:this')
+                            .map(name => {
+                                const sourcePropertyName = name.substr(5);
+
+                                let targetPropertyName = sourcePropertyName;
+
+                                const attributeValue = attrs[name];
+
+                                if (attributeValue && attributeValue.length > 0) {
+                                    targetPropertyName = attributeValue;
+                                }
+
+                                return {
+                                    sourcePropertyName: sourcePropertyName,
+                                    targetPropertyName: targetPropertyName,
+                                    parent: tagName,
+                                    locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, name)
+                                        ? [lastAttributeLocations[name]]
+                                        : null
+                                };
+                            });
+
+                        bindProperties.forEach(bindProperty => {
+                            const dataItem = {
+                                name: bindProperty.targetPropertyName,
+                                kind: undefined,
+                                bind: [{
+                                    source: bindProperty.parent,
+                                    property: bindProperty.sourcePropertyName
+                                }],
+                                locations: bindProperty.locations,
+                                visibility: 'private',
+                                static: false,
+                                readonly: false
+                            };
+
+                            this.emit(TemplateEvent.DATA, dataItem);
+                        });
+                    }
+
+                    if (this.features.includes('refs')) {
+                        if (hasOwnProperty(attrs, 'bind:this') && attrs['bind:this']) {
+                            const bindedVariableName = attrs['bind:this'];
+
+                            const refItem = {
+                                visibility: 'private',
+                                name: bindedVariableName,
+                                parent: tagName,
+                                locations: this.includeSourceLocations && hasOwnProperty(lastAttributeLocations, 'bind:this')
+                                    ? [lastAttributeLocations['bind:this']]
+                                    : null
+                            };
+
+                            this.emit(TemplateEvent.REF, refItem);
+                        }
+                    }
+                }
+            }
+        };
+    }
+}
+
+module.exports = TemplateParser;
+module.exports.TemplateEvent = TemplateEvent;

--- a/lib/v3/v3-utils.js
+++ b/lib/v3/v3-utils.js
@@ -40,6 +40,19 @@ const RETURN_ALIASES = {
 };
 
 /**
+ * Returns the innermost body prop from node.
+ * returns the same node if it does not have a body.
+ * @param {AstNode & { body?: AstNode | AstNode[] }} node an AST node
+ */
+function getInnermostBody(node) {
+    while (node && node.body) {
+        node = node.body;
+    }
+
+    return node;
+}
+
+/**
  * @param {AstNode} node a 'FunctionDeclaration' AST node
  */
 function parseFunctionDeclaration(node) {
@@ -184,6 +197,8 @@ function parseAndMergeKeywords(keywords = [], event) {
 }
 
 module.exports = {
+    assertNodeType,
+    getInnermostBody,
     parseFunctionDeclaration,
     parseVariableDeclaration,
     parseAndMergeKeywords,

--- a/lib/v3/v3-utils.js
+++ b/lib/v3/v3-utils.js
@@ -7,7 +7,7 @@ const {
 class InvalidNodeTypeError extends TypeError {
     constructor(expected, actual = '', ...args) {
         super(expected, actual, ...args);
-        this.message = `Node should be of type '${expected}', but it was ${actual}.`;
+        this.message = `Expected node type to be '${expected}', but it was '${actual}'.`;
     }
 }
 
@@ -129,7 +129,7 @@ function parseVariableDeclaration(node) {
 /**
  * @sideEffect Mutates `item.type`.
  *
- * Updates the item.type` from `@type` in `item.keywords`, if any.
+ * Updates `item.type` from `@type` in `item.keywords`, if any.
  *
  * @param {{ name: string; description: string}[]} item
  */

--- a/lib/v3/v3-utils.js
+++ b/lib/v3/v3-utils.js
@@ -1,0 +1,191 @@
+const {
+    parseParamKeyword,
+    parseReturnKeyword,
+    parseTypeKeyword
+} = require('../jsdoc');
+
+class InvalidNodeTypeError extends TypeError {
+    constructor(expected, actual = '', ...args) {
+        super(expected, actual, ...args);
+        this.message = `Node should be of type '${expected}', but it was ${actual}.`;
+    }
+}
+
+/**
+ * @typedef {{ type: string }} AstNode
+ */
+
+/**
+ * @throws InvalidNodeTypeError if the node is not of the correct type
+ * @param {AstNode} node
+ * @param {string} type
+ */
+function assertNodeType(node, type) {
+    if (node.type !== type) {
+        throw new InvalidNodeTypeError(type, node.type);
+    }
+}
+
+/** All `@param` JSDoc aliases. */
+const PARAM_ALIASES = {
+    arg: true,
+    argument: true,
+    param: true
+};
+
+/** All `@returns` JSDoc aliases. */
+const RETURN_ALIASES = {
+    return: true,
+    returns: true,
+};
+
+/**
+ * @param {AstNode} node a 'FunctionDeclaration' AST node
+ */
+function parseFunctionDeclaration(node) {
+    assertNodeType(node, 'FunctionDeclaration');
+
+    const params = [];
+
+    node.params.forEach((param) => {
+        if (param.type === 'Identifier') {
+            params.push({
+                name: param.name,
+            });
+        }
+    });
+
+    const output = {
+        node: node,
+        name: node.id.name,
+        location: {
+            start: node.id.start,
+            end: node.id.end
+        },
+        params: params,
+    };
+
+    return output;
+}
+
+/**
+ * @param {AstNode} node a 'VariableDeclaration' AST node
+ */
+function parseVariableDeclaration(node) {
+    assertNodeType(node, 'VariableDeclaration');
+
+    const result = [];
+
+    node.declarations.forEach(declarator => {
+        const idNode = declarator.id;
+
+        if (idNode.type === 'Identifier') {
+            result.push({
+                name: idNode.name,
+                kind: node.kind,
+                node: node,
+                declarator: declarator,
+                location: {
+                    start: idNode.start,
+                    end: idNode.end
+                }
+            });
+        } else if (idNode.type === 'ObjectPattern') {
+            idNode.properties.forEach(propertyNode => {
+                const propertyIdNode = propertyNode.key;
+
+                if (propertyIdNode.type === 'Identifier') {
+                    result.push({
+                        name: propertyIdNode.name,
+                        kind: node.kind,
+                        node: node,
+                        declarator: declarator,
+                        locations: {
+                            start: propertyIdNode.start,
+                            end: propertyIdNode.end
+                        }
+                    });
+                }
+            });
+        }
+    });
+
+    return result;
+}
+
+/**
+ * @sideEffect Mutates `item.type`.
+ *
+ * Updates the item.type` from `@type` in `item.keywords`, if any.
+ *
+ * @param {{ name: string; description: string}[]} item
+ */
+function updateType(item) {
+    const typeKeyword = item.keywords.find(kw => kw.name === 'type');
+
+    if (typeKeyword) {
+        const parsedType = parseTypeKeyword(typeKeyword.description);
+
+        if (parsedType) {
+            item.type = parsedType;
+        }
+    }
+}
+
+/**
+ * @sideEffect Mutates `event.params` and `event.return`.
+ *
+ * Parses the `keywords` argument and merges the result in `event`.
+ *
+ * If a param exists as a JSDoc `@param`, it will overwrite the param of the
+ * same name already in event, if any. If a `@param` in JSDoc does
+ * not match the name of an actual param of the function, it is appended at
+ * end of the `event` params.
+ *
+ * @param {{ name: string; description: string}[]} keywords
+ * @param {{ params?: any[]; return?: any }} event
+ */
+function parseAndMergeKeywords(keywords = [], event) {
+    if (!event.params) {
+        event.params = [];
+    }
+
+    keywords.forEach(({ name, description }) => {
+        if (name in PARAM_ALIASES) {
+            const parsedParam = parseParamKeyword(description);
+            const pIndex = event.params.findIndex(
+                p => p.name === parsedParam.name
+            );
+
+            /*
+             * Replace the param if there is already one present with
+             * the same name. This will happen with parsed
+             * FunctionDeclaration because params will already be
+             * present from parsing the AST node.
+             */
+            if (pIndex >= 0) {
+                event.params[pIndex] = parsedParam;
+            } else {
+                /*
+                 * This means @param does not match an actual param
+                 * in the FunctionDeclaration. For now, we keep it.
+                 * TODO: Implement option to choose behaviour (keep, ignore, warn, throw)
+                 */
+                event.params.push(parsedParam);
+            }
+        } else if (name in RETURN_ALIASES) {
+            event.return = parseReturnKeyword(description);
+        }
+    });
+
+    if (event.params.length === 0) {
+        delete event.params;
+    }
+}
+
+module.exports = {
+    parseFunctionDeclaration,
+    parseVariableDeclaration,
+    parseAndMergeKeywords,
+    updateType,
+};

--- a/test/svelte3/integration/events/event.dispatcher.identifier.svelte
+++ b/test/svelte3/integration/events/event.dispatcher.identifier.svelte
@@ -7,10 +7,18 @@
             NOTIFY: 'notify'
         }
     };
-
     const SIMPLE_EVENT = 'plain-notify';
 
     dispatch(EVENT.SIGNAL.NOTIFY);
-
     dispatch(SIMPLE_EVENT);
+
+    export const EXPORTED_EVENT = {
+        SIGNAL: {
+            NOTIFY: 'exported-notify'
+        }
+    };
+    export const EXPORTED_SIMPLE_EVENT = 'exported-plain-notify';
+
+    dispatch(EXPORTED_EVENT.SIGNAL.NOTIFY);
+    dispatch(EXPORTED_SIMPLE_EVENT);
 </script>

--- a/test/svelte3/integration/events/events.spec.js
+++ b/test/svelte3/integration/events/events.spec.js
@@ -333,7 +333,7 @@ describe('SvelteDoc v3 - Events', () => {
         }).then((doc) => {
             expect(doc, 'Document should be provided').to.exist;
             expect(doc.events, 'Document events should be parsed').to.exist;
-            expect(doc.events.length).to.equal(2);
+            expect(doc.events.length).to.equal(4);
 
             let event = doc.events[0];
 
@@ -345,6 +345,18 @@ describe('SvelteDoc v3 - Events', () => {
 
             expect(event, 'Event should be a valid entity').to.exist;
             expect(event.name).to.equal('plain-notify');
+            expect(event.visibility).to.equal('public');
+
+            event = doc.events[2];
+
+            expect(event, 'Event should be a valid entity').to.exist;
+            expect(event.name).to.equal('exported-notify');
+            expect(event.visibility).to.equal('public');
+
+            event = doc.events[3];
+
+            expect(event, 'Event should be a valid entity').to.exist;
+            expect(event.name).to.equal('exported-plain-notify');
             expect(event.visibility).to.equal('public');
 
             done();

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -70,18 +70,7 @@ export type JSVisibilityScope = 'public' | 'protected' | 'private';
 
 export type JSVariableDeclarationKind = 'var' | 'let' | 'const';
 
-export interface ISvelteItem {
-    /**
-     * The name of the item.
-     */
-    name: string;
-
-    /**
-     * The list of source code locations for this item.
-     * Provided only if requested by specific option parameter.
-     */
-    locations?: SourceLocation[];
-
+export interface IScopedCommentItem {
     /**
      * The description of the item, provided from related comment.
      */
@@ -94,6 +83,19 @@ export interface ISvelteItem {
      * The list of parsed JSDoc keywords from related comment.
      */
     keywords?: JSDocKeyword[];
+}
+
+export interface ISvelteItem extends IScopedCommentItem {
+    /**
+     * The name of the item.
+     */
+    name: string;
+
+    /**
+     * The list of source code locations for this item.
+     * Provided only if requested by specific option parameter.
+     */
+    locations?: SourceLocation[];
 }
 
 export interface SvelteDataBindMapping {


### PR DESCRIPTION
The parser has been split into two sub-parsers:
- `ScriptParser` parses:
  - the top level script blocks; and
  - the javascript expressions found in the template
- `TemplateParser` parses the template (previously named markup)
  - it delegates to `ScriptParser` when it finds a javascript expression. This way, the `identifiers` and `dispatchers` of the top level scripts are shared with the template javascript expression.

Both sub-parsers emit events that are caught by the main Parser:
- Some events are re-emitted as is (mainly the events from `TemplateParser`)
- Other events are intercepted, augmented, and then emitted.